### PR TITLE
Hotfix: Show selected token in review page 

### DIFF
--- a/src/pages/review/hooks/use-stake-review.hook.ts
+++ b/src/pages/review/hooks/use-stake-review.hook.ts
@@ -50,8 +50,9 @@ export const useStakeReview = () => {
     [pricesState.data, selectedStake, stakeEnterTxGas]
   );
 
-  const token = selectedStake.map((y) => y.token);
   const metadata = selectedStake.map((y) => y.metadata);
+
+  const token = selectedTokenBalance.map((y) => y.token);
 
   const navigate = useNavigate();
 


### PR DESCRIPTION
## Changed

Use the selected token balance token instead of the yield metadata token. 
