### PR TITLE
ENG-2809: Balance formatting + toggle

### DIFF
--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stakekit/widget",
-  "version": "0.0.180",
+  "version": "0.0.181",
   "type": "module",
   "main": "./dist/package/index.package.js",
   "types": "./dist/types/index.package.d.ts",

--- a/packages/widget/src/components/molecules/amount-toggle/index.tsx
+++ b/packages/widget/src/components/molecules/amount-toggle/index.tsx
@@ -1,0 +1,62 @@
+import { Box } from "@sk-widget/components/atoms/box";
+import {
+  type Dispatch,
+  type PropsWithChildren,
+  type ReactNode,
+  type SetStateAction,
+  createContext,
+  useContext,
+  useState,
+} from "react";
+
+type State = "full" | "short";
+
+type RootProps = {
+  init?: State;
+};
+
+const Context = createContext<
+  [State, Dispatch<SetStateAction<State>>] | undefined
+>(undefined);
+
+const Root = ({ children, init }: PropsWithChildren<RootProps>) => (
+  <Context.Provider value={useState(init ?? "short")}>
+    {children}
+  </Context.Provider>
+);
+
+type AmountProps =
+  | {
+      fullAmount: string;
+      shortAmount: string;
+      children?: never;
+    }
+  | {
+      fullAmount?: never;
+      shortAmount?: never;
+      children: (props: { state: State }) => ReactNode;
+    };
+
+const Amount = ({ fullAmount, shortAmount, children }: AmountProps) => {
+  const [state, setState] = useAmountContext();
+
+  const toggle = () => setState(state === "full" ? "short" : "full");
+
+  return (
+    <Box as="button" onClick={toggle}>
+      {children?.({ state }) ?? (state === "full" ? fullAmount : shortAmount)}
+    </Box>
+  );
+};
+
+const useAmountContext = () => {
+  const ctx = useContext(Context);
+
+  if (!ctx) {
+    throw new Error("useAmountContext must be used within a Root");
+  }
+
+  return ctx;
+};
+
+export { Root, Amount, useAmountContext };

--- a/packages/widget/src/components/molecules/reward-token-details/index.tsx
+++ b/packages/widget/src/components/molecules/reward-token-details/index.tsx
@@ -46,6 +46,7 @@ export const RewardTokenDetails = ({
                 justifyContent="center"
                 alignItems="center"
                 gap="1"
+                alignSelf="flex-start"
               >
                 <Image
                   imageProps={{ borderRadius: "full" }}

--- a/packages/widget/src/pages/details/earn-page/components/select-token-section/index.tsx
+++ b/packages/widget/src/pages/details/earn-page/components/select-token-section/index.tsx
@@ -1,10 +1,11 @@
 import { Box, NumberInput, Text } from "@sk-widget/components";
 import { ContentLoaderSquare } from "@sk-widget/components/atoms/content-loader";
 import { MaxButton } from "@sk-widget/components/atoms/max-button";
+import * as AmountToggle from "@sk-widget/components/molecules/amount-toggle";
 import { priceTxt } from "@sk-widget/pages/details/earn-page/components/select-token-section/styles.css";
 import { useEarnPageContext } from "@sk-widget/pages/details/earn-page/state/earn-page-context";
 import { useSettings } from "@sk-widget/providers/settings";
-import { Just, Maybe } from "purify-ts";
+import { Just } from "purify-ts";
 import { useTranslation } from "react-i18next";
 import { SelectToken } from "./select-token";
 import { SelectTokenTitle } from "./title";
@@ -16,7 +17,7 @@ export const SelectTokenSection = () => {
 
   const {
     appLoading,
-    availableTokens,
+    selectedTokenAvailableAmount,
     formattedPrice,
     onMaxClick,
     onStakeAmountChange,
@@ -147,28 +148,35 @@ export const SelectTokenSection = () => {
               }}
               data-state={errorBalance ? "error" : "valid"}
             >
-              {Maybe.fromNullable(availableTokens)
+              {selectedTokenAvailableAmount
                 .map((v) =>
                   variant === "zerion" ? (
                     <>
-                      <span>{t("shared.balance")}:</span>{" "}
-                      {
-                        <Box
-                          {...(isStakeTokenSameAsGasToken
-                            ? { as: "span" }
-                            : {
-                                onClick: onMaxClick,
-                                as: "button",
-                              })}
-                        >
-                          {v}
-                        </Box>
-                      }
+                      <span>{t("shared.balance")}:&nbsp;</span>
+                      <Box
+                        {...(isStakeTokenSameAsGasToken
+                          ? { as: "span" }
+                          : {
+                              onClick: onMaxClick,
+                              as: "button",
+                            })}
+                      >
+                        {v.shortFormattedAmount}&nbsp;{v.symbol}
+                      </Box>
                     </>
                   ) : (
-                    <>
-                      <span>{v}</span> <span>{t("shared.available")}</span>
-                    </>
+                    <AmountToggle.Root>
+                      <AmountToggle.Amount>
+                        {({ state }) => (
+                          <span>
+                            {state === "full"
+                              ? v.fullFormattedAmount
+                              : v.shortFormattedAmount}
+                            &nbsp;{v.symbol}&nbsp;{t("shared.available")}
+                          </span>
+                        )}
+                      </AmountToggle.Amount>
+                    </AmountToggle.Root>
                   )
                 )
                 .extractNullable()}

--- a/packages/widget/src/pages/details/earn-page/state/earn-page-context.tsx
+++ b/packages/widget/src/pages/details/earn-page/state/earn-page-context.tsx
@@ -148,14 +148,15 @@ export const EarnPageContextProvider = ({ children }: PropsWithChildren) => {
     [baseToken, pricesState.data, selectedToken, stakeAmount]
   );
 
-  const formattedAmount = useMemo(
-    () => availableAmount.mapOrDefault((am) => formatNumber(am), ""),
-    [availableAmount]
-  );
-
-  const availableTokens = useMemo(
-    () => `${formattedAmount} ${symbol}`.trim(),
-    [formattedAmount, symbol]
+  const selectedTokenAvailableAmount = useMemo(
+    () =>
+      availableAmount.map((am) => ({
+        symbol,
+        shortFormattedAmount: defaultFormattedNumber(am),
+        fullFormattedAmount: formatNumber(am),
+        amount: am,
+      })),
+    [availableAmount, symbol]
   );
 
   const [stakeSearch, setStakeSearch] = useState("");
@@ -620,7 +621,7 @@ export const EarnPageContextProvider = ({ children }: PropsWithChildren) => {
 
   const value = {
     referralCheck,
-    availableTokens,
+    selectedTokenAvailableAmount,
     formattedPrice,
     symbol,
     selectedStakeData,

--- a/packages/widget/src/pages/details/earn-page/state/types.ts
+++ b/packages/widget/src/pages/details/earn-page/state/types.ts
@@ -63,7 +63,12 @@ export type ExtraData = {
 
 export type EarnPageContextType = {
   referralCheck: SettingsContextType["referralCheck"];
-  availableTokens: string;
+  selectedTokenAvailableAmount: Maybe<{
+    symbol: string;
+    shortFormattedAmount: string;
+    fullFormattedAmount: string;
+    amount: BigNumber;
+  }>;
   formattedPrice: string;
   symbol: string;
   selectedStakeData: Maybe<SelectedStakeData>;

--- a/packages/widget/src/pages/position-details/components/amount-block.tsx
+++ b/packages/widget/src/pages/position-details/components/amount-block.tsx
@@ -8,9 +8,10 @@ import {
 } from "@sk-widget/components";
 import { InfoIcon } from "@sk-widget/components/atoms/icons/info";
 import { MaxButton } from "@sk-widget/components/atoms/max-button";
+import * as AmountToggle from "@sk-widget/components/molecules/amount-toggle";
 import { useYieldMetaInfo } from "@sk-widget/hooks/use-yield-meta-info";
 import { priceTxt } from "@sk-widget/pages/position-details/styles.css";
-import { formatNumber } from "@sk-widget/utils";
+import { defaultFormattedNumber, formatNumber } from "@sk-widget/utils";
 import type { TokenDto, ValidatorDto, YieldDto } from "@stakekit/api-hooks";
 import BigNumber from "bignumber.js";
 import { Just, Maybe } from "purify-ts";
@@ -168,12 +169,21 @@ export const AmountBlock = ({
               alignItems="center"
             >
               {balance && (
-                <Text variant={{ weight: "normal" }}>
-                  {t("position_details.available", {
-                    amount: formatNumber(balance.amount),
-                    symbol: balance.token?.symbol ?? "",
-                  })}
-                </Text>
+                <AmountToggle.Root>
+                  <AmountToggle.Amount>
+                    {({ state }) => (
+                      <Text variant={{ weight: "normal" }}>
+                        {t("position_details.available", {
+                          amount:
+                            state === "full"
+                              ? formatNumber(balance.amount)
+                              : defaultFormattedNumber(balance.amount),
+                          symbol: balance.token?.symbol ?? "",
+                        })}
+                      </Text>
+                    )}
+                  </AmountToggle.Amount>
+                </AmountToggle.Root>
               )}
               {canChangeAmount && onMaxClick && (
                 <MaxButton


### PR DESCRIPTION
## Added

- Available stake/unstake amounts are shown in short format (6 decimals). Clicking it toggles to full format

## Changed

_Description of the modifications made to existing functionality, feature, or content in this pull request. This could include changes to code, CI, documentation, etc._
