### PR TITLE
YIE-143: yuma validator only

### DIFF
--- a/.changeset/thin-teeth-tickle.md
+++ b/.changeset/thin-teeth-tickle.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+feat: yuma validator only

--- a/packages/widget/src/components/atoms/image/index.tsx
+++ b/packages/widget/src/components/atoms/image/index.tsx
@@ -53,13 +53,15 @@ export const Image = ({
     imageProps?.onError?.(e);
   };
 
-  const showFallback = useMemo(
-    () =>
-      ((src && failLoadImages.has(src)) ||
-        (loadState.timeoutFallback && !loadState.loaded)) &&
-      isValidElement(fallback),
-    [fallback, loadState.loaded, loadState.timeoutFallback, src]
-  );
+  const showFallback = useMemo(() => {
+    if (!isValidElement(fallback)) return false;
+
+    return (
+      !src ||
+      failLoadImages.has(src) ||
+      (loadState.timeoutFallback && !loadState.loaded)
+    );
+  }, [fallback, loadState.loaded, loadState.timeoutFallback, src]);
 
   return (
     <Box

--- a/packages/widget/src/domain/types/yields.ts
+++ b/packages/widget/src/domain/types/yields.ts
@@ -122,3 +122,6 @@ export const getYieldProviderYieldIds = (yieldDto: YieldDto) =>
 
 export const isEthenaUsdeStaking = (yieldId: string) =>
   yieldId === "ethena-usde-staking";
+
+export const isBittensorStaking = (yieldId: string) =>
+  yieldId === "bittensor-native-staking";

--- a/packages/widget/src/hooks/api/use-yield-opportunity/get-yield-opportunity.ts
+++ b/packages/widget/src/hooks/api/use-yield-opportunity/get-yield-opportunity.ts
@@ -2,7 +2,10 @@ import type { YieldDto } from "@stakekit/api-hooks";
 import type { QueryClient } from "@tanstack/react-query";
 import { EitherAsync } from "purify-ts";
 import { yieldYieldOpportunity } from "../../../common/private-api";
-import { isEthenaUsdeStaking } from "../../../domain/types/yields";
+import {
+  isBittensorStaking,
+  isEthenaUsdeStaking,
+} from "../../../domain/types/yields";
 
 type Params = {
   yieldId: string;
@@ -76,7 +79,12 @@ const fn = ({
               name: y.metadata.name.replace(/staking/i, ""),
             },
           } satisfies YieldDto)
-        : y
+        : isBittensorStaking(y.id)
+          ? {
+              ...y,
+              validators: y.validators.filter((v) => v.name?.match(/yuma/i)),
+            }
+          : y
     )
     .mapLeft((e) => {
       console.log(e);


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `@stakekit/widget` package. The changes include refining the fallback logic for the `Image` component, adding support for a new staking type (`bittensor-native-staking`), and updating the yield opportunity logic to filter validators based on specific criteria. Below is a breakdown of the most significant changes:

### Feature Enhancements

* [`.changeset/thin-teeth-tickle.md`](diffhunk://#diff-ee81dca93f9c2f6b5e8726910dfa12fab51b9fb76df6780ed16fcdc55e2979d5R1-R5): Added a patch release note for the `@stakekit/widget` package, highlighting the new "yuma validator only" feature.

### Component Improvements

* [`packages/widget/src/components/atoms/image/index.tsx`](diffhunk://#diff-fa2a7aeefb09a45ee4bd71284a527a4b967251dc18d5a68136c642c40fd80d81L56-R64): Refined the `showFallback` logic in the `Image` component to ensure proper fallback behavior by explicitly checking for valid fallback elements and handling edge cases more effectively.

### Domain Logic Updates

* [`packages/widget/src/domain/types/yields.ts`](diffhunk://#diff-0ec8d795e263f33dcc30755869b04ad7eb207fa3f59ac9751c5f7ea7b2f6e4e7R125-R127): Introduced a new utility function, `isBittensorStaking`, to identify `bittensor-native-staking` yield types.

### API Hook Modifications

* [`packages/widget/src/hooks/api/use-yield-opportunity/get-yield-opportunity.ts`](diffhunk://#diff-315e491c570e7b72ab9158a91dd65e4d30b0506499d014a2a04a52040c439608L5-R8): Updated imports to include `isBittensorStaking` and modified the yield opportunity logic to filter validators for `bittensor-native-staking` based on the presence of "yuma" in their names. [[1]](diffhunk://#diff-315e491c570e7b72ab9158a91dd65e4d30b0506499d014a2a04a52040c439608L5-R8) [[2]](diffhunk://#diff-315e491c570e7b72ab9158a91dd65e4d30b0506499d014a2a04a52040c439608R82-R86)