### PR TITLE
feat: init token and yield when disconnected

### DIFF
--- a/.changeset/warm-worms-study.md
+++ b/.changeset/warm-worms-study.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+feat: init token and yield when disconnected

--- a/packages/widget/src/domain/types/stake.ts
+++ b/packages/widget/src/domain/types/stake.ts
@@ -53,6 +53,11 @@ export const getInitialToken = (args: {
         .chain((n) =>
           Maybe.fromNullable(args.preferredTokenYieldsPerNetwork?.[n])
         )
+        .altLazy(() =>
+          Maybe.fromNullable(args.preferredTokenYieldsPerNetwork).chainNullable(
+            (v) => Object.values(v)[0]
+          )
+        )
         .chain((preferredTokens) =>
           List.find(
             (val) => !!preferredTokens[tokenString(val.token)],

--- a/packages/widget/src/hooks/api/use-multi-yields.ts
+++ b/packages/widget/src/hooks/api/use-multi-yields.ts
@@ -194,10 +194,17 @@ const firstEligibleYield$ = (args: {
       defaultYield = v;
     }),
     filter((y) => {
-      const preferredYieldId =
+      const preferredYieldId = Maybe.fromNullable(
         args.preferredTokenYieldsPerNetwork?.[
           y.token.network as SupportedSKChains
-        ]?.[tokenString(y.token)];
+        ]?.[tokenString(y.token)]
+      )
+        .altLazy(() =>
+          Maybe.fromNullable(args.preferredTokenYieldsPerNetwork).chainNullable(
+            (v) => Object.values(v)[0][tokenString(y.token)]
+          )
+        )
+        .extractNullable();
 
       if (preferredYieldId) {
         return y.id === preferredYieldId || preferredYieldId === "*";


### PR DESCRIPTION
This pull request introduces improvements to how the widget initializes tokens and yields when there is no direct connection or when preferred token/yield information is missing. The main focus is to provide sensible defaults by falling back to the first available token or yield in these cases.

Enhancements to default token and yield initialization:

* Updated `getInitialToken` in `stake.ts` to fall back to the first available token yield when a preferred token yield is not specified, ensuring smoother initialization when disconnected.
* Modified `firstEligibleYield in `use-multi-yields.ts` to select the first available yield as a fallback if the preferred yield is not found, improving robustness in yield selection logic.

Changelog update:

* Added a patch changelog entry describing the new fallback logic for token and yield initialization when disconnected.