### PR TITLE
feat: hoodi chain support

### DIFF
--- a/.changeset/stale-swans-report.md
+++ b/.changeset/stale-swans-report.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+feat: hoodi chain support

--- a/packages/widget/src/domain/types/chains/evm.ts
+++ b/packages/widget/src/domain/types/chains/evm.ts
@@ -10,7 +10,7 @@ import {
   gnosis,
   goerli,
   harmonyOne,
-  holesky,
+  hoodi,
   linea,
   mainnet,
   optimism,
@@ -20,6 +20,7 @@ import {
   unichain,
   viction,
 } from "viem/chains";
+import type { KebabToCamelCase } from "../../../types/utils";
 import { getNetworkLogo } from "../../../utils";
 
 const supportedEVMChains = [
@@ -33,7 +34,7 @@ const supportedEVMChains = [
   EvmNetworks.Optimism,
   EvmNetworks.Polygon,
   EvmNetworks.Viction,
-  EvmNetworks.EthereumHolesky,
+  EvmNetworks.EthereumHoodi,
   EvmNetworks.Base,
   EvmNetworks.Linea,
   EvmNetworks.Core,
@@ -142,10 +143,10 @@ export const evmChainsMap: EvmChainsMap = {
       iconUrl: getNetworkLogo(EvmNetworks.Sonic),
     },
   },
-  [EvmNetworks.EthereumHolesky]: {
+  [EvmNetworks.EthereumHoodi]: {
     type: "evm",
-    skChainName: EvmNetworks.EthereumHolesky,
-    wagmiChain: holesky,
+    skChainName: EvmNetworks.EthereumHoodi,
+    wagmiChain: hoodi,
   },
   [EvmNetworks.EthereumGoerli]: {
     type: "evm",
@@ -202,9 +203,15 @@ export enum EvmChainIds {
   Linea = 59_144,
   Core = 1116,
   Sonic = 146,
-  EthereumHolesky = 17000,
+  EthereumHoodi = 560048,
   EthereumGoerli = 5,
   EthereumSepolia = 11_155_111,
   Unichain = 130,
   Katana = 747474,
+  Gnosis = 100,
 }
+
+EvmChainIds satisfies Record<
+  Capitalize<KebabToCamelCase<SupportedEvmChain>>,
+  number
+>;

--- a/packages/widget/src/domain/types/chains/ledger.ts
+++ b/packages/widget/src/domain/types/chains/ledger.ts
@@ -96,10 +96,10 @@ export const supportedLedgerFamiliesWithCurrency = {
       family: "ethereum",
       skChainName: EvmNetworks.AvalancheC,
     },
-    ethereum_holesky: {
-      currencyId: "ethereum_holesky",
+    ethereum_hoodi: {
+      currencyId: "ethereum_hoodi",
       family: "ethereum",
-      skChainName: EvmNetworks.EthereumHolesky,
+      skChainName: EvmNetworks.EthereumHoodi,
     },
     bsc: {
       currencyId: "bsc",

--- a/packages/widget/src/domain/types/chains/misc.ts
+++ b/packages/widget/src/domain/types/chains/misc.ts
@@ -1,5 +1,6 @@
 import { MiscNetworks } from "@stakekit/common";
 import type { Chain } from "@stakekit/rainbowkit";
+import type { KebabToCamelCase } from "../../../types/utils";
 import { getTokenLogo } from "../../../utils";
 
 const supportedMiscChains = [
@@ -132,3 +133,8 @@ export enum MiscChainIds {
   Tron = 79,
   Ton = 3412,
 }
+
+MiscChainIds satisfies Record<
+  Capitalize<KebabToCamelCase<SupportedMiscChains>>,
+  number
+>;

--- a/packages/widget/src/domain/types/chains/substrate.ts
+++ b/packages/widget/src/domain/types/chains/substrate.ts
@@ -1,5 +1,6 @@
 import { SubstrateNetworks } from "@stakekit/common";
 import type { Chain } from "@stakekit/rainbowkit";
+import type { KebabToCamelCase } from "../../../types/utils";
 import { getNetworkLogo } from "../../../utils";
 
 const supportedSubstrateChains = [
@@ -81,3 +82,8 @@ export enum SubstrateChainIds {
   Polkadot = 9999,
   Bittensor = 558,
 }
+
+SubstrateChainIds satisfies Record<
+  Capitalize<KebabToCamelCase<SupportedSubstrateChains>>,
+  number
+>;

--- a/packages/widget/src/types/utils.ts
+++ b/packages/widget/src/types/utils.ts
@@ -19,3 +19,8 @@ export type Action<T extends string, D = void> = D extends void
   : { type: T; data: D };
 
 export type Nullable<T> = T | undefined | null;
+
+export type KebabToCamelCase<S extends string> =
+  S extends `${infer P1}-${infer P2}${infer P3}`
+    ? `${P1}${Capitalize<KebabToCamelCase<`${P2}${P3}`>>}`
+    : S;


### PR DESCRIPTION
This pull request adds support for the Hoodi chain to the widget and improves type safety for chain ID enums. The main changes include replacing the previous Holesky chain references with Hoodi, updating related configuration and type definitions, and introducing a utility type for converting kebab-case strings to CamelCase, which is now used to validate enum mappings.

**Hoodi chain support and configuration updates:**

* Replaced all references to Holesky with Hoodi in the EVM chain configuration, including imports, supported chains list, chain mapping (`evmChainsMap`), and the `EvmChainIds` enum. (`packages/widget/src/domain/types/chains/evm.ts`, [[1]](diffhunk://#diff-c24cde4bfd9d9fa655e20ed7975389169a64bb21032fd22fa1dc3fdf54d38c7fL13-R13) [[2]](diffhunk://#diff-c24cde4bfd9d9fa655e20ed7975389169a64bb21032fd22fa1dc3fdf54d38c7fL36-R37) [[3]](diffhunk://#diff-c24cde4bfd9d9fa655e20ed7975389169a64bb21032fd22fa1dc3fdf54d38c7fL145-R149) [[4]](diffhunk://#diff-c24cde4bfd9d9fa655e20ed7975389169a64bb21032fd22fa1dc3fdf54d38c7fL205-R217)
* Updated the Ledger family configuration to use `ethereum_hoodi` instead of `ethereum_holesky`, reflecting the new chain support. (`packages/widget/src/domain/types/chains/ledger.ts`, [packages/widget/src/domain/types/chains/ledger.tsL99-R102](diffhunk://#diff-468f8fb0ec8b58a5c3259d9d05c8fdcd0f20761e7fe1418a0692ac9381329b7eL99-R102))

**Type safety improvements:**

* Added a utility type `KebabToCamelCase` and used it to assert that chain ID enums (`EvmChainIds`, `MiscChainIds`, `SubstrateChainIds`) match the expected naming conventions, improving type safety and maintainability. (`packages/widget/src/types/utils.ts`, [[1]](diffhunk://#diff-ab14fae3b7542cfbd578f9e6713220974180505639c55e4247c2fa5f4e28a9f8R22-R26); `packages/widget/src/domain/types/chains/evm.ts`, [[2]](diffhunk://#diff-c24cde4bfd9d9fa655e20ed7975389169a64bb21032fd22fa1dc3fdf54d38c7fR23) [[3]](diffhunk://#diff-c24cde4bfd9d9fa655e20ed7975389169a64bb21032fd22fa1dc3fdf54d38c7fL205-R217); `packages/widget/src/domain/types/chains/misc.ts`, [[4]](diffhunk://#diff-f9051c9415302ec512ce8da0be1ecbe498fee29e34a7cbb8ab2a199e4f9e0f00R3) [[5]](diffhunk://#diff-f9051c9415302ec512ce8da0be1ecbe498fee29e34a7cbb8ab2a199e4f9e0f00R136-R140); `packages/widget/src/domain/types/chains/substrate.ts`, [[6]](diffhunk://#diff-573577b4dcc6bccfa2426fee6857babb3d7b7e214ac70d614572857b8c1eb6d8R3) [[7]](diffhunk://#diff-573577b4dcc6bccfa2426fee6857babb3d7b7e214ac70d614572857b8c1eb6d8R85-R89)

**Changelog:**

* Added a patch changelog entry for Hoodi chain support. (`.changeset/stale-swans-report.md`, [.changeset/stale-swans-report.mdR1-R5](diffhunk://#diff-1b46a0fac0e786737b1f075e7fd17dd57ab804e35e47c76d0b9a60b2271ccd87R1-R5))