### PR TITLE
fix: array sort

### DIFF
--- a/.changeset/cute-tables-smell.md
+++ b/.changeset/cute-tables-smell.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+fix: use .sort instead of .toSorted

--- a/packages/widget/src/hooks/use-positions-data.ts
+++ b/packages/widget/src/hooks/use-positions-data.ts
@@ -28,8 +28,8 @@ const positionsDataSelector = createSelector(
     balancesData.reduce((acc, val) => {
       acc.set(val.integrationId, {
         integrationId: val.integrationId,
-        balanceData: val.balances
-          .toSorted((a, b) => (a.groupId ?? "").localeCompare(b.groupId ?? ""))
+        balanceData: [...val.balances]
+          .sort((a, b) => (a.groupId ?? "").localeCompare(b.groupId ?? ""))
           .reduce((acc, b) => {
             const prev = acc.get(b.groupId);
 

--- a/packages/widget/src/pages/details/earn-page/state/earn-page-context.tsx
+++ b/packages/widget/src/pages/details/earn-page/state/earn-page-context.tsx
@@ -235,7 +235,7 @@ export const EarnPageContextProvider = ({ children }: PropsWithChildren) => {
   const selectedStakeData = useMemo<Maybe<SelectedStakeData>>(
     () =>
       Maybe.of(multiYields)
-        .map((val) => val.toSorted((a, b) => b.apy - a.apy))
+        .map((val) => [...val].sort((a, b) => b.apy - a.apy))
         .map((val) => val.filter((v) => v.apy > 0))
         .chain((yieldDtos) =>
           Maybe.of(deferredStakeSearch)
@@ -259,7 +259,7 @@ export const EarnPageContextProvider = ({ children }: PropsWithChildren) => {
             .alt(Maybe.of({ all: yieldDtos, filteredDtos: yieldDtos }))
         )
         .map(({ all, filteredDtos }) => {
-          const sorted = filteredDtos.toSorted(
+          const sorted = [...filteredDtos].sort(
             (a, b) => getYieldTypesSortRank(a) - getYieldTypesSortRank(b)
           );
 
@@ -328,7 +328,9 @@ export const EarnPageContextProvider = ({ children }: PropsWithChildren) => {
           .alt(Maybe.of(ss.validators))
           .map((validators) => {
             if (variant === "utila") {
-              return validators.toSorted((a, b) => (b.apr ?? 0) - (a.apr ?? 0));
+              return [...validators].sort(
+                (a, b) => (b.apr ?? 0) - (a.apr ?? 0)
+              );
             }
 
             return validators;

--- a/packages/widget/src/pages/details/positions-page/hooks/use-positions.ts
+++ b/packages/widget/src/pages/details/positions-page/hooks/use-positions.ts
@@ -134,7 +134,7 @@ const positionsTableDataSelector = createSelector(
       )
       .map((val) =>
         variant === "zerion"
-          ? val.toSorted((a, b) => {
+          ? [...val].sort((a, b) => {
               if (a.hasPendingClaimRewards) return -1;
               if (b.hasPendingClaimRewards) return 1;
               return 0;

--- a/packages/widget/src/providers/cosmos/wallet-manager.ts
+++ b/packages/widget/src/providers/cosmos/wallet-manager.ts
@@ -56,7 +56,7 @@ export const getWalletManager = ({
     )
     .map((val) => ({
       ...val,
-      chains: val.chains.toSorted((a) =>
+      chains: [...val.chains].sort((a) =>
         // Put cosmos first
         registryIdsToSKCosmosNetworks[a.chain_id] === CosmosNetworks.Cosmos
           ? -1


### PR DESCRIPTION
This pull request addresses compatibility issues by replacing the use of `.toSorted` with the more widely supported `.sort` method throughout the codebase. This ensures that sorting operations work reliably across all supported environments.

**Sorting compatibility fixes:**

* Replaced `.toSorted` with `[...array].sort(...)` for sorting `balances` by `groupId` in `use-positions-data.ts` to ensure compatibility.
* Updated sorting of `multiYields` by `apy`, `filteredDtos` by yield type rank, and `validators` by `apr` in `earn-page-context.tsx` to use `[...array].sort(...)` instead of `.toSorted`. [[1]](diffhunk://#diff-bb26a7babef3df6f0f96455dfbcb999a8985157cb7860226c1d3981376ef6cb3L238-R238) [[2]](diffhunk://#diff-bb26a7babef3df6f0f96455dfbcb999a8985157cb7860226c1d3981376ef6cb3L262-R262) [[3]](diffhunk://#diff-bb26a7babef3df6f0f96455dfbcb999a8985157cb7860226c1d3981376ef6cb3L331-R333)
* Changed sorting of `val` by pending claim rewards in `use-positions.ts` to `[...val].sort(...)`.
* Updated sorting of `chains` in `wallet-manager.ts` to `[...val.chains].sort(...)`.

**Changelog update:**

* Added a patch changelog entry for `@stakekit/widget` documenting the switch from `.toSorted` to `.sort`.