### PR TITLE
fix: rainbowkit dialog root

### DIFF
--- a/.changeset/late-chicken-divide.md
+++ b/.changeset/late-chicken-divide.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+fix: rainbowkit dialog root

--- a/packages/examples/with-cdn-script/index.mjs
+++ b/packages/examples/with-cdn-script/index.mjs
@@ -1,45 +1,34 @@
 import {
-  darkTheme,
+  lightTheme,
   renderSKWidget,
-} from "https://unpkg.com/@stakekit/widget@0.0.248/dist/bundle/index.bundle.js";
+} from "https://unpkg.com/@stakekit/widget@0.0.249/dist/bundle/index.bundle.js";
 
 const rootElement = document.getElementById("widget-container");
 
 const shadowRoot = rootElement.attachShadow({ mode: "closed" });
+const shadowHead = document.createElement("head");
+const shadowBody = document.createElement("body");
 
-const head = document.createElement("head");
+shadowRoot.appendChild(shadowHead);
+shadowRoot.appendChild(shadowBody);
 
 const link = document.createElement("link");
 link.rel = "stylesheet";
 link.href =
-  "https://unpkg.com/@stakekit/widget@0.0.248/dist/bundle/index.bundle.css";
-head.appendChild(link);
+  "https://unpkg.com/@stakekit/widget@0.0.249/dist/bundle/index.bundle.css";
 
-shadowRoot.appendChild(head);
+shadowHead.appendChild(link);
 document.head.appendChild(link.cloneNode());
-
-const shadowBody = document.createElement("body");
-shadowRoot.appendChild(shadowBody);
 
 const shadowContainer = document.createElement("div");
 shadowContainer.style.all = "initial";
-shadowRoot.appendChild(shadowContainer);
+
+shadowBody.appendChild(shadowContainer);
 
 renderSKWidget({
   container: shadowContainer,
-  theme: darkTheme,
+  theme: lightTheme,
   apiKey: "e2d627cf-2ae3-4775-9fbc-76819c7cae38",
-  portalContainer: shadowBody,
+  portalContainer: shadowContainer,
+  dashboardVariant: true,
 });
-
-const observer = new MutationObserver(() => {
-  const runtimeStyles = shadowContainer.querySelectorAll(
-    '[data-rk="stakekit"] > style'
-  );
-
-  runtimeStyles.forEach((style) => {
-    document.head.appendChild(style.cloneNode(true));
-  });
-});
-
-observer.observe(shadowContainer, { childList: true });

--- a/packages/widget/src/providers/rainbow-kit.tsx
+++ b/packages/widget/src/providers/rainbow-kit.tsx
@@ -29,6 +29,8 @@ export const RainbowKitProviderWithTheme = ({
 }: PropsWithChildren) => {
   const { connector, connectorChains } = useSKWallet();
 
+  const { portalContainer } = useSettings();
+
   const ledgerDisabledChains = useLedgerDisabledChain(connector);
 
   const trackEvent = useTrackEvent();
@@ -76,6 +78,7 @@ export const RainbowKitProviderWithTheme = ({
       showRecentTransactions={false}
       theme={finalTheme}
       hideDisconnect={hideDisconnect}
+      dialogRoot={portalContainer}
     >
       <DisabledChainHandling />
       {children}


### PR DESCRIPTION
This pull request introduces a patch to `@stakekit/widget` that primarily fixes an issue with the RainbowKit dialog root. The changes focus on improving theme handling, updating the CDN bundle version, and ensuring the dialog renders correctly in the intended container. The most important changes are grouped below:

**Widget Integration and Theming:**

* Updated the CDN bundle and stylesheet references in `index.mjs` to version `0.0.249`, switched from `darkTheme` to `lightTheme`, and refactored the shadow DOM structure for better encapsulation.
* Changed the widget's `portalContainer` prop to use the `shadowContainer` instead of `shadowBody` for more reliable dialog placement.

**RainbowKit Dialog Root Fix:**

* Passed the `portalContainer` from widget settings as the `dialogRoot` prop to `RainbowKitProvider`, ensuring dialogs render in the correct DOM node. [[1]](diffhunk://#diff-90f28e5a321f331c9101f0d944b4553c479997a19b12d514b2cdf36520c65902R32-R33) [[2]](diffhunk://#diff-90f28e5a321f331c9101f0d944b4553c479997a19b12d514b2cdf36520c65902R81)

**Maintenance and Cleanup:**

* Removed the mutation observer logic from `index.mjs` that previously copied runtime styles from the widget container to the document head, simplifying style management.

**Release and Documentation:**

* Added a patch changeset for `@stakekit/widget` documenting the RainbowKit dialog root fix.