### PR TITLE
feat: trust reallocate

### DIFF
--- a/.changeset/hungry-fans-build.md
+++ b/.changeset/hungry-fans-build.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+feat: trust reallocate

--- a/packages/widget/src/components/atoms/select-modal/index.tsx
+++ b/packages/widget/src/components/atoms/select-modal/index.tsx
@@ -3,7 +3,7 @@ import { Root as VisuallyHiddenRoot } from "@radix-ui/react-visually-hidden";
 import type { ChangeEvent, PropsWithChildren, ReactNode } from "react";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useSavedRef } from "../../../hooks/use-saved-ref";
-import { useSettings } from "../../../providers/settings";
+import { SettingsContext } from "../../../providers/settings";
 import { id } from "../../../styles/theme/ids";
 import { Box } from "../box";
 import { SearchIcon } from "../icons/search";
@@ -51,6 +51,7 @@ type SelectModalContextType = {
 
 export type SelectModalProps = SelectModalWithoutStateProps & {
   state?: SelectModalContextType;
+  portalContainer?: HTMLElement;
 };
 
 const SelectModalContext = createContext<SelectModalContextType | undefined>(
@@ -80,9 +81,9 @@ const SelectModalWithoutState = ({
   errorMessage,
   disableClose,
   hideTopBar,
+  portalContainer,
 }: SelectModalProps) => {
   const { isOpen, setOpen } = useSelectModalContext();
-  const { portalContainer } = useSettings();
 
   const onCloseRef = useSavedRef(onClose);
   const onOpenRef = useSavedRef(onOpen);
@@ -101,7 +102,11 @@ const SelectModalWithoutState = ({
     <Root open={isOpen} onOpenChange={setOpen}>
       {trigger}
 
-      <Portal container={portalContainer}>
+      <Portal
+        container={
+          useContext(SettingsContext)?.portalContainer ?? portalContainer
+        }
+      >
         <Box className={container} data-select-modal data-rk={id}>
           <Overlay onClick={() => setOpen(false)} className={overlay} />
 

--- a/packages/widget/src/components/molecules/reallocate-bottom-banner/index.tsx
+++ b/packages/widget/src/components/molecules/reallocate-bottom-banner/index.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from "react-i18next";
+import { Box } from "../../atoms/box";
+import { Balance } from "../../atoms/icons/balance";
+import { Text } from "../../atoms/typography/text";
+import { bottomBanner, bottomBannerText } from "./styles.css";
+
+export const ReallocateBottomBanner = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Box
+      className={bottomBanner}
+      px="2"
+      py="3"
+      display="flex"
+      gap="2"
+      justifyContent="center"
+    >
+      <Balance />
+      <Text className={bottomBannerText}>
+        {t("position_details.trust_reallocate")}
+      </Text>
+    </Box>
+  );
+};

--- a/packages/widget/src/components/molecules/reallocate-bottom-banner/styles.css.ts
+++ b/packages/widget/src/components/molecules/reallocate-bottom-banner/styles.css.ts
@@ -1,0 +1,18 @@
+import { style } from "@vanilla-extract/css";
+import { atoms } from "../../../styles/theme/atoms.css";
+import { vars } from "../../../styles/theme/contract.css";
+
+export const bottomBanner = style([
+  atoms({ borderRadius: "xl" }),
+  {
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
+    background:
+      "linear-gradient(90deg, #166534 0%, #16A34A 25.78%, #22C55E 59.59%, #14532D 100%)",
+  },
+]);
+
+export const bottomBannerText = style({
+  fontSize: "12px",
+  color: vars.color.white,
+});

--- a/packages/widget/src/main.tsx
+++ b/packages/widget/src/main.tsx
@@ -39,6 +39,7 @@ const StandaloneApp = () => {
         forceWalletConnectOnly: true,
       },
     }),
+    isTrust: true,
   };
 
   return (

--- a/packages/widget/src/pages/details/positions-page/components/positions-list-item.tsx
+++ b/packages/widget/src/pages/details/positions-page/components/positions-list-item.tsx
@@ -1,5 +1,6 @@
+import clsx from "clsx";
 import { List, Maybe } from "purify-ts";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Box } from "../../../../components/atoms/box";
 import { ContentLoaderSquare } from "../../../../components/atoms/content-loader";
@@ -9,7 +10,9 @@ import { Spinner } from "../../../../components/atoms/spinner";
 import { TokenIcon } from "../../../../components/atoms/token-icon";
 import { ToolTip } from "../../../../components/atoms/tooltip";
 import { Text } from "../../../../components/atoms/typography/text";
+import { ReallocateBottomBanner } from "../../../../components/molecules/reallocate-bottom-banner";
 import type { PositionDetailsLabelType } from "../../../../domain/types/positions";
+import { useSettings } from "../../../../providers/settings";
 import { usePositionListItem } from "../hooks/use-position-list-item";
 import type { usePositions } from "../hooks/use-positions";
 import {
@@ -17,7 +20,7 @@ import {
   positionDetailsContainer,
   viaText,
 } from "../style.css";
-import { listItem, noWrap } from "./styles.css";
+import { bottomBannerBottomRadius, listItem, noWrap } from "./styles.css";
 
 export const PositionsListItem = memo(
   ({
@@ -26,6 +29,17 @@ export const PositionsListItem = memo(
     item: ReturnType<typeof usePositions>["positionsData"]["data"][number];
   }) => {
     const { t } = useTranslation();
+
+    const { isTrust } = useSettings();
+
+    const showTrustRelocateBanner = useMemo(() => {
+      return (
+        isTrust &&
+        item.allBalances.some((b) =>
+          b.pendingActions.some((pa) => pa.type === "RESTAKE")
+        )
+      );
+    }, [isTrust, item.allBalances]);
 
     const {
       integrationData,
@@ -43,181 +57,189 @@ export const PositionsListItem = memo(
         <Box py="1">
           {integrationData.mapOrDefault(
             (d) => (
-              <ListItem className={listItem}>
-                <Box
-                  display="flex"
-                  width="full"
-                  justifyContent="space-between"
-                  gap="2"
+              <>
+                <ListItem
+                  className={clsx(listItem, {
+                    [bottomBannerBottomRadius]: showTrustRelocateBanner,
+                  })}
                 >
                   <Box
                     display="flex"
-                    justifyContent="flex-start"
-                    alignItems="center"
+                    width="full"
+                    justifyContent="space-between"
+                    gap="2"
                   >
-                    {item.token.mapOrDefault(
-                      (val) => (
-                        <TokenIcon metadata={d.metadata} token={val} />
-                      ),
-                      <Box display="flex" marginRight="2">
-                        <Spinner />
-                      </Box>
-                    )}
-
                     <Box
                       display="flex"
-                      flexDirection="column"
-                      justifyContent="center"
-                      alignItems="flex-start"
-                      gap="1"
+                      justifyContent="flex-start"
+                      alignItems="center"
                     >
-                      <Box className={positionDetailsContainer}>
-                        {item.token
-                          .map((t) => <Text>{t.symbol}</Text>)
-                          .extractNullable()}
+                      {item.token.mapOrDefault(
+                        (val) => (
+                          <TokenIcon metadata={d.metadata} token={val} />
+                        ),
+                        <Box display="flex" marginRight="2">
+                          <Spinner />
+                        </Box>
+                      )}
 
-                        {item.yieldLabelDto
-                          .map((label) => {
-                            return (
-                              <ToolTip
-                                textAlign="left"
-                                maxWidth={300}
-                                label={t(
-                                  `position_details.labels.${label.type as PositionDetailsLabelType}.details`,
-                                  label.params as
-                                    | Record<string, string>
-                                    | undefined
-                                )}
-                              >
-                                <Box
-                                  className={listItemContainer({
-                                    type: "actionRequired",
-                                  })}
-                                >
-                                  <Text
-                                    variant={{ type: "white" }}
-                                    className={noWrap}
-                                  >
-                                    {t(
-                                      `position_details.labels.${label.type as PositionDetailsLabelType}.label`
-                                    )}
-                                  </Text>
-                                </Box>
-                              </ToolTip>
-                            );
-                          })
-                          .extractNullable()}
-                        {(item.actionRequired ||
-                          item.hasPendingClaimRewards ||
-                          !!inactiveValidator) && (
-                          <Box
-                            className={listItemContainer({
-                              type: item.actionRequired
-                                ? "actionRequired"
-                                : inactiveValidator
-                                  ? "actionRequired"
-                                  : "claim",
-                            })}
-                          >
-                            <Text
-                              variant={{ type: "white" }}
-                              className={noWrap}
-                            >
-                              {t(
-                                item.actionRequired
-                                  ? "positions.action_required"
-                                  : inactiveValidator
-                                    ? inactiveValidator === "jailed"
-                                      ? "details.validators_jailed"
-                                      : "details.validators_inactive"
-                                    : "positions.claim_rewards"
-                              )}
-                            </Text>
-                          </Box>
-                        )}
-                      </Box>
-                      {providersDetails
-                        .chain((val) =>
-                          List.head(val).map((p) => (
-                            <Text
-                              className={viaText}
-                              variant={{
-                                type: "muted",
-                                weight: "normal",
-                              }}
-                            >
-                              {t("positions.via", {
-                                providerName: p.name ?? p.address,
-                                count: Math.max(val.length - 1, 1),
-                              })}
-                            </Text>
-                          ))
-                        )
-                        .extractNullable()}
-                    </Box>
-                  </Box>
-
-                  {Maybe.fromRecord({
-                    token: item.token,
-                    rewardRateAverage,
-                    totalAmountFormatted,
-                  })
-                    .map((val) => (
                       <Box
                         display="flex"
-                        justifyContent="center"
-                        alignItems="flex-end"
                         flexDirection="column"
-                        textAlign="end"
-                        gap="1"
-                      >
-                        <Text variant={{ weight: "normal" }}>
-                          {item.actionRequired ? " " : val.rewardRateAverage}
-                        </Text>
-
-                        <Text
-                          overflowWrap="anywhere"
-                          variant={{ weight: "normal", type: "muted" }}
-                        >
-                          {val.totalAmountFormatted} {val.token.symbol}
-                        </Text>
-                      </Box>
-                    ))
-                    .extractNullable()}
-                </Box>
-
-                {item.pointsRewardTokenBalances.length > 0 && (
-                  <Box display="flex" alignSelf="flex-end" gap="1">
-                    {item.pointsRewardTokenBalances.map((val, i) => (
-                      <Box
-                        key={i}
-                        alignSelf="flex-end"
-                        background="background"
-                        display="flex"
-                        alignItems="center"
                         justifyContent="center"
-                        borderRadius="lg"
-                        px="2"
-                        py="1"
+                        alignItems="flex-start"
                         gap="1"
                       >
-                        <TokenIcon
-                          token={val.token}
-                          hideNetwork
-                          tokenLogoHw="5"
-                        />
+                        <Box className={positionDetailsContainer}>
+                          {item.token
+                            .map((t) => <Text>{t.symbol}</Text>)
+                            .extractNullable()}
 
-                        <Text
-                          overflowWrap="anywhere"
-                          variant={{ type: "muted", weight: "normal" }}
-                        >
-                          {val.amount}
-                        </Text>
+                          {item.yieldLabelDto
+                            .map((label) => {
+                              return (
+                                <ToolTip
+                                  textAlign="left"
+                                  maxWidth={300}
+                                  label={t(
+                                    `position_details.labels.${label.type as PositionDetailsLabelType}.details`,
+                                    label.params as
+                                      | Record<string, string>
+                                      | undefined
+                                  )}
+                                >
+                                  <Box
+                                    className={listItemContainer({
+                                      type: "actionRequired",
+                                    })}
+                                  >
+                                    <Text
+                                      variant={{ type: "white" }}
+                                      className={noWrap}
+                                    >
+                                      {t(
+                                        `position_details.labels.${label.type as PositionDetailsLabelType}.label`
+                                      )}
+                                    </Text>
+                                  </Box>
+                                </ToolTip>
+                              );
+                            })
+                            .extractNullable()}
+                          {(item.actionRequired ||
+                            item.hasPendingClaimRewards ||
+                            !!inactiveValidator) && (
+                            <Box
+                              className={listItemContainer({
+                                type: item.actionRequired
+                                  ? "actionRequired"
+                                  : inactiveValidator
+                                    ? "actionRequired"
+                                    : "claim",
+                              })}
+                            >
+                              <Text
+                                variant={{ type: "white" }}
+                                className={noWrap}
+                              >
+                                {t(
+                                  item.actionRequired
+                                    ? "positions.action_required"
+                                    : inactiveValidator
+                                      ? inactiveValidator === "jailed"
+                                        ? "details.validators_jailed"
+                                        : "details.validators_inactive"
+                                      : "positions.claim_rewards"
+                                )}
+                              </Text>
+                            </Box>
+                          )}
+                        </Box>
+                        {providersDetails
+                          .chain((val) =>
+                            List.head(val).map((p) => (
+                              <Text
+                                className={viaText}
+                                variant={{
+                                  type: "muted",
+                                  weight: "normal",
+                                }}
+                              >
+                                {t("positions.via", {
+                                  providerName: p.name ?? p.address,
+                                  count: Math.max(val.length - 1, 1),
+                                })}
+                              </Text>
+                            ))
+                          )
+                          .extractNullable()}
                       </Box>
-                    ))}
+                    </Box>
+
+                    {Maybe.fromRecord({
+                      token: item.token,
+                      rewardRateAverage,
+                      totalAmountFormatted,
+                    })
+                      .map((val) => (
+                        <Box
+                          display="flex"
+                          justifyContent="center"
+                          alignItems="flex-end"
+                          flexDirection="column"
+                          textAlign="end"
+                          gap="1"
+                        >
+                          <Text variant={{ weight: "normal" }}>
+                            {item.actionRequired ? " " : val.rewardRateAverage}
+                          </Text>
+
+                          <Text
+                            overflowWrap="anywhere"
+                            variant={{ weight: "normal", type: "muted" }}
+                          >
+                            {val.totalAmountFormatted} {val.token.symbol}
+                          </Text>
+                        </Box>
+                      ))
+                      .extractNullable()}
                   </Box>
-                )}
-              </ListItem>
+
+                  {item.pointsRewardTokenBalances.length > 0 && (
+                    <Box display="flex" alignSelf="flex-end" gap="1">
+                      {item.pointsRewardTokenBalances.map((val, i) => (
+                        <Box
+                          key={i}
+                          alignSelf="flex-end"
+                          background="background"
+                          display="flex"
+                          alignItems="center"
+                          justifyContent="center"
+                          borderRadius="lg"
+                          px="2"
+                          py="1"
+                          gap="1"
+                        >
+                          <TokenIcon
+                            token={val.token}
+                            hideNetwork
+                            tokenLogoHw="5"
+                          />
+
+                          <Text
+                            overflowWrap="anywhere"
+                            variant={{ type: "muted", weight: "normal" }}
+                          >
+                            {val.amount}
+                          </Text>
+                        </Box>
+                      ))}
+                    </Box>
+                  )}
+                </ListItem>
+
+                {showTrustRelocateBanner && <ReallocateBottomBanner />}
+              </>
             ),
             <ContentLoaderSquare heightPx={60} />
           )}

--- a/packages/widget/src/pages/details/positions-page/components/styles.css.ts
+++ b/packages/widget/src/pages/details/positions-page/components/styles.css.ts
@@ -38,3 +38,8 @@ export const columnContainer = style([
     minWidth: "0",
   },
 ]);
+
+export const bottomBannerBottomRadius = style({
+  borderBottomLeftRadius: 0,
+  borderBottomRightRadius: 0,
+});

--- a/packages/widget/src/pages/position-details/components/static-action-block.tsx
+++ b/packages/widget/src/pages/position-details/components/static-action-block.tsx
@@ -5,13 +5,18 @@ import type {
   YieldDto,
 } from "@stakekit/api-hooks";
 import BigNumber from "bignumber.js";
+import clsx from "clsx";
+import { useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Box } from "../../../components/atoms/box";
 import { Button } from "../../../components/atoms/button";
 import { Text } from "../../../components/atoms/typography/text";
+import { ReallocateBottomBanner } from "../../../components/molecules/reallocate-bottom-banner";
 import { isEthenaUsdeStaking } from "../../../domain/types/yields";
+import { useSettings } from "../../../providers/settings";
 import { formatNumber } from "../../../utils";
 import type { usePositionDetails } from "../hooks/use-position-details";
+import { bottomBannerBottomRadius } from "../styles.css";
 
 type StaticActionBlockProps = {
   pendingActionDto: PendingActionDto;
@@ -32,71 +37,87 @@ export const StaticActionBlock = ({
 }: StaticActionBlockProps) => {
   const { t } = useTranslation();
 
+  const { isTrust } = useSettings();
+
+  const showTrustRelocateBanner = useMemo(
+    () =>
+      isTrust &&
+      yieldBalance.pendingActions.some((pa) => pa.type === "RESTAKE"),
+    [isTrust, yieldBalance.pendingActions]
+  );
+
   return (
-    <Box
-      display="flex"
-      justifyContent="space-between"
-      alignItems="center"
-      px="4"
-      py="4"
-      borderRadius="2xl"
-      borderColor="backgroundMuted"
-      borderWidth={1}
-      borderStyle="solid"
-    >
-      <Box flex={2}>
-        <Text variant={{ weight: "normal" }}>
-          <Trans
-            i18nKey="position_details.available_to"
-            values={{
-              amount: formatNumber(new BigNumber(yieldBalance.amount)),
-              symbol: yieldBalance.token.symbol,
-              pendingAction: t(
-                `position_details.pending_action.${
+    <Box>
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        px="4"
+        py="4"
+        borderRadius="2xl"
+        borderColor="backgroundMuted"
+        borderWidth={1}
+        borderStyle="solid"
+        className={clsx({
+          [bottomBannerBottomRadius]: showTrustRelocateBanner,
+        })}
+      >
+        <Box flex={2}>
+          <Text variant={{ weight: "normal" }}>
+            <Trans
+              i18nKey="position_details.available_to"
+              values={{
+                amount: formatNumber(new BigNumber(yieldBalance.amount)),
+                symbol: yieldBalance.token.symbol,
+                pendingAction: t(
+                  `position_details.pending_action.${
+                    pendingActionDto.type.toLowerCase() as Lowercase<ActionTypes>
+                  }`,
+                  {
+                    context: isEthenaUsdeStaking(yieldId)
+                      ? "ethena_usde"
+                      : undefined,
+                  }
+                ),
+              }}
+              components={{
+                bold: <Box as="span" fontWeight="bold" display="block" />,
+              }}
+            />
+          </Text>
+        </Box>
+
+        <Box
+          flex={1}
+          maxWidth="24"
+          justifyContent="flex-end"
+          display="flex"
+          alignItems="center"
+        >
+          <Button
+            variant={{
+              size: "small",
+              color: "smallButtonLight",
+            }}
+            onClick={() =>
+              onPendingActionClick({
+                yieldBalance: yieldBalance,
+                pendingActionDto: pendingActionDto,
+              })
+            }
+          >
+            <Text>
+              {t(
+                `position_details.pending_action_button.${
                   pendingActionDto.type.toLowerCase() as Lowercase<ActionTypes>
-                }`,
-                {
-                  context: isEthenaUsdeStaking(yieldId)
-                    ? "ethena_usde"
-                    : undefined,
-                }
-              ),
-            }}
-            components={{
-              bold: <Box as="span" fontWeight="bold" display="block" />,
-            }}
-          />
-        </Text>
+                }`
+              )}
+            </Text>
+          </Button>
+        </Box>
       </Box>
 
-      <Box
-        flex={1}
-        maxWidth="24"
-        justifyContent="flex-end"
-        display="flex"
-        alignItems="center"
-      >
-        <Button
-          variant={{
-            size: "small",
-            color: "smallButtonLight",
-          }}
-          onClick={() =>
-            onPendingActionClick({
-              yieldBalance: yieldBalance,
-              pendingActionDto: pendingActionDto,
-            })
-          }
-        >
-          <Text>
-            {t(
-              `position_details.pending_action_button.${
-                pendingActionDto.type.toLowerCase() as Lowercase<ActionTypes>
-              }`
-            )}
-          </Text>
-        </Button>
-      </Box>
+      {showTrustRelocateBanner && <ReallocateBottomBanner />}
     </Box>
   );
 };

--- a/packages/widget/src/pages/position-details/styles.css.ts
+++ b/packages/widget/src/pages/position-details/styles.css.ts
@@ -35,3 +35,9 @@ export const unstakeSignContainer = style({
 export const priceTxt = style({
   flexGrow: 999,
 });
+
+export const bottomBannerBottomRadius = style({
+  borderBottomLeftRadius: 0,
+  borderBottomRightRadius: 0,
+  borderBottomWidth: 0,
+});

--- a/packages/widget/src/providers/settings/index.tsx
+++ b/packages/widget/src/providers/settings/index.tsx
@@ -6,7 +6,7 @@ import { config } from "../../config";
 import utilaTranslations from "../../translation/English/utila-variant.json";
 import type { SettingsContextType } from "./types";
 
-const SettingsContext = createContext<SettingsContextType | undefined>(
+export const SettingsContext = createContext<SettingsContextType | undefined>(
   undefined
 );
 

--- a/packages/widget/src/providers/settings/types.ts
+++ b/packages/widget/src/providers/settings/types.ts
@@ -61,6 +61,7 @@ export type SettingsProps = {
   showUSDeBanner?: boolean;
   preferredTokenYieldsPerNetwork?: PreferredTokenYieldsPerNetwork;
   portalContainer?: HTMLElement;
+  isTrust?: boolean;
 };
 
 export type SettingsContextType = SettingsProps & VariantProps;

--- a/packages/widget/src/translation/English/translations.json
+++ b/packages/widget/src/translation/English/translations.json
@@ -424,6 +424,7 @@
     }
   },
   "position_details": {
+    "trust_reallocate": "Relocate to Earn Up to 14.28% More.",
     "labels": {
       "hasFrozenV1": {
         "label": "Frozen 1.0",


### PR DESCRIPTION
This pull request introduces a new "Trust Reallocate" feature to the widget, including UI enhancements and context updates to support it. The main changes are the addition of a bottom banner component that highlights potential additional earnings, conditional rendering of this banner in relevant UI components, and updates to context and types to enable trust-specific behavior.

**Trust Reallocate Feature Implementation**

* Added the `ReallocateBottomBanner` component, which displays a message about earning up to 14.28% more through reallocation. Includes new styles for the banner. [[1]](diffhunk://#diff-5809628c9d93967f4a7667f1e4d3b3141f2e371b181b4330f9d135b1365ae05eR1-R25) [[2]](diffhunk://#diff-9513c21f20424c4477cf055bee31066d8c0a300f4bc71990b0ab5ebd0cd44984R1-R24)
* Updated the translation files to include a new string for the trust reallocate banner.

**Conditional Banner Rendering**

* Integrated the `ReallocateBottomBanner` into `PositionsListItem` and `StaticActionBlock` components, with logic to display it only for trust-enabled contexts and relevant pending actions. [[1]](diffhunk://#diff-97acd330c54ddfbf872ff3bc5cc7bede12e5ca07bca4a7ec670b79dad99e716bR1-R3) [[2]](diffhunk://#diff-97acd330c54ddfbf872ff3bc5cc7bede12e5ca07bca4a7ec670b79dad99e716bR33-R43) [[3]](diffhunk://#diff-97acd330c54ddfbf872ff3bc5cc7bede12e5ca07bca4a7ec670b79dad99e716bL46-R65) [[4]](diffhunk://#diff-97acd330c54ddfbf872ff3bc5cc7bede12e5ca07bca4a7ec670b79dad99e716bR240-R242) [[5]](diffhunk://#diff-0db9e6f834cf5982cdb1254cf400a395d16c2ea60b72475a6db8af8471a6832cR8-R19) [[6]](diffhunk://#diff-0db9e6f834cf5982cdb1254cf400a395d16c2ea60b72475a6db8af8471a6832cR40-R50) [[7]](diffhunk://#diff-0db9e6f834cf5982cdb1254cf400a395d16c2ea60b72475a6db8af8471a6832cR61-R63) [[8]](diffhunk://#diff-0db9e6f834cf5982cdb1254cf400a395d16c2ea60b72475a6db8af8471a6832cR119-R121)

**Context and Type Updates**

* Updated the `SettingsContext` and related types to support the new `isTrust` flag and `portalContainer`, allowing for trust-specific UI logic and portal container customization. [[1]](diffhunk://#diff-566732864fb5bf5c1957c9ae14de821540d44f0746641a91bc41849248856cb7L9-R9) [[2]](diffhunk://#diff-6ea8368701bded70f0441c2babb38b96db27ca6d0ab87e044a7ac3d2c90d97a6R64) [[3]](diffhunk://#diff-71aaa404974b1b4621e98ed8827ea077a6c7c98c98cc3cb7b3e54205178f1492R42) [[4]](diffhunk://#diff-6445db23699cb0eb966626b5e4f47115454fd9c6a105bd0d880145f9fa33e361L6-R6) [[5]](diffhunk://#diff-6445db23699cb0eb966626b5e4f47115454fd9c6a105bd0d880145f9fa33e361R54) [[6]](diffhunk://#diff-6445db23699cb0eb966626b5e4f47115454fd9c6a105bd0d880145f9fa33e361R84-L85) [[7]](diffhunk://#diff-6445db23699cb0eb966626b5e4f47115454fd9c6a105bd0d880145f9fa33e361L104-R109)

**Style Enhancements**

* Added new CSS styles for the bottom banner and adjusted border radius styles to ensure visual consistency when the banner is displayed. [[1]](diffhunk://#diff-9513c21f20424c4477cf055bee31066d8c0a300f4bc71990b0ab5ebd0cd44984R1-R24) [[2]](diffhunk://#diff-d3535a5fdc9f9976e33788bf87c3f2f76809ecf5a3063c7ace2e07ab87416ae2R41-R45) [[3]](diffhunk://#diff-fc5eb2d933d870605f10b630001df005cf2289ae42e3adae1cc1729482abd45fR38-R43)

**Changelog Entry**

* Added a patch changelog entry for the `@stakekit/widget` package, documenting the trust reallocate feature.