### PR TITLE
fix: remove use settings from select modal

### DIFF
--- a/.changeset/silver-socks-taste.md
+++ b/.changeset/silver-socks-taste.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+fix: remove use context from select modal

--- a/packages/widget/src/components/atoms/select-modal/index.tsx
+++ b/packages/widget/src/components/atoms/select-modal/index.tsx
@@ -3,7 +3,7 @@ import { Root as VisuallyHiddenRoot } from "@radix-ui/react-visually-hidden";
 import type { ChangeEvent, PropsWithChildren, ReactNode } from "react";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useSavedRef } from "../../../hooks/use-saved-ref";
-import { useSettings } from "../../../providers/settings";
+import { SettingsContext } from "../../../providers/settings";
 import { id } from "../../../styles/theme/ids";
 import { Box } from "../box";
 import { SearchIcon } from "../icons/search";
@@ -51,6 +51,7 @@ type SelectModalContextType = {
 
 export type SelectModalProps = SelectModalWithoutStateProps & {
   state?: SelectModalContextType;
+  portalContainer?: HTMLElement;
 };
 
 const SelectModalContext = createContext<SelectModalContextType | undefined>(
@@ -80,9 +81,9 @@ const SelectModalWithoutState = ({
   errorMessage,
   disableClose,
   hideTopBar,
+  portalContainer,
 }: SelectModalProps) => {
   const { isOpen, setOpen } = useSelectModalContext();
-  const { portalContainer } = useSettings();
 
   const onCloseRef = useSavedRef(onClose);
   const onOpenRef = useSavedRef(onOpen);
@@ -101,7 +102,11 @@ const SelectModalWithoutState = ({
     <Root open={isOpen} onOpenChange={setOpen}>
       {trigger}
 
-      <Portal container={portalContainer}>
+      <Portal
+        container={
+          useContext(SettingsContext)?.portalContainer ?? portalContainer
+        }
+      >
         <Box className={container} data-select-modal data-rk={id}>
           <Overlay onClick={() => setOpen(false)} className={overlay} />
 

--- a/packages/widget/src/providers/settings/index.tsx
+++ b/packages/widget/src/providers/settings/index.tsx
@@ -6,7 +6,7 @@ import { config } from "../../config";
 import utilaTranslations from "../../translation/English/utila-variant.json";
 import type { SettingsContextType } from "./types";
 
-const SettingsContext = createContext<SettingsContextType | undefined>(
+export const SettingsContext = createContext<SettingsContextType | undefined>(
   undefined
 );
 


### PR DESCRIPTION
This pull request addresses a bug in the `@stakekit/widget` package by refactoring how the `portalContainer` is provided to the select modal component. The main change is to remove the direct use of context from the select modal and rely on props or context in a more controlled way. This improves component encapsulation and flexibility.

**Refactoring of portal container handling:**

* The `SelectModal` component now accepts a `portalContainer` prop, allowing consumers to specify the portal's container element directly.
* The select modal retrieves `portalContainer` from the `SettingsContext` only if it is not provided via props, reducing unnecessary context usage and making the component more reusable. [[1]](diffhunk://#diff-6445db23699cb0eb966626b5e4f47115454fd9c6a105bd0d880145f9fa33e361R84-L85) [[2]](diffhunk://#diff-6445db23699cb0eb966626b5e4f47115454fd9c6a105bd0d880145f9fa33e361L104-R109)
* The import for `SettingsContext` is updated to use a named export, and `SettingsContext` is now exported from its module to support direct usage. [[1]](diffhunk://#diff-6445db23699cb0eb966626b5e4f47115454fd9c6a105bd0d880145f9fa33e361L6-R6) [[2]](diffhunk://#diff-566732864fb5bf5c1957c9ae14de821540d44f0746641a91bc41849248856cb7L9-R9)

**General bug fix:**

* Removes the use of context from the select modal to resolve issues related to modal rendering and context dependency.