### PR TITLE
fix: private

### DIFF
--- a/packages/examples/with-cdn-script/package.json
+++ b/packages/examples/with-cdn-script/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@stakekit/with-cdn-script",
+  "private": true,
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
This pull request makes a small change to the `package.json` file for the `@stakekit/with-cdn-script` package, marking the package as private to prevent it from being published to the npm registry.