### PR TITLE
fix: finery solana connectors

### DIFF
--- a/.changeset/great-states-sleep.md
+++ b/.changeset/great-states-sleep.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+fix: finery solana connectors

--- a/packages/widget/src/providers/wagmi/index.ts
+++ b/packages/widget/src/providers/wagmi/index.ts
@@ -175,13 +175,6 @@ const buildWagmiConfig = async (opts: {
             } as RainbowkitChain;
           };
 
-          if (opts.variant === "finery") {
-            return Object.values(evmConfig.evmChainsMap).map(mapWagmiChain) as [
-              RainbowkitChain,
-              ...RainbowkitChain[],
-            ];
-          }
-
           return Object.values({
             ...evmConfig.evmChainsMap,
             ...cosmosConfig.cosmosChainsMap,
@@ -190,13 +183,6 @@ const buildWagmiConfig = async (opts: {
           }).map(mapWagmiChain) as [RainbowkitChain, ...RainbowkitChain[]];
         })
         .orDefaultLazy(() => {
-          if (opts.variant === "finery") {
-            return evmConfig.evmChains as [
-              RainbowkitChain,
-              ...RainbowkitChain[],
-            ];
-          }
-
           return [
             ...evmConfig.evmChains,
             ...cosmosConfig.cosmosWagmiChains,
@@ -222,6 +208,7 @@ const buildWagmiConfig = async (opts: {
               groupName: "Other",
               wallets: evmConfig.fineryWallets.otherWallets,
             },
+            ...Maybe.catMaybes(miscConfig.connectors),
           ];
         }
 


### PR DESCRIPTION
This pull request addresses a patch for the Solana connectors in the Finery variant of the StakeKit widget, focusing on fixing connector issues and cleaning up related logic. The main changes are in how chain and wallet connectors are handled for the Finery variant, with unnecessary branching removed and improved connector inclusion.

**Solana connector fixes and Finery variant improvements:**

* Removed special-case logic for the Finery variant in the `buildWagmiConfig` function, simplifying chain selection and preventing duplicate or inconsistent connector handling. [[1]](diffhunk://#diff-ea4416aa38e669d2e611d5df3a93b72078c281a4b2a4424a7061a6dcf5110c6eL178-L184) [[2]](diffhunk://#diff-ea4416aa38e669d2e611d5df3a93b72078c281a4b2a4424a7061a6dcf5110c6eL193-L199)
* Ensured that miscellaneous connectors from `miscConfig.connectors` are included in the wallet connector list, which helps address missing or broken Solana connectors for the Finery variant.

**Release and documentation:**

* Added a patch release note for `@stakekit/widget` describing the Solana connector fix for Finery in `.changeset/great-states-sleep.md`.