### PR TITLE
fix: query params lowercase compare

### DIFF
--- a/.changeset/honest-snakes-flash.md
+++ b/.changeset/honest-snakes-flash.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+fix: query params lowercase compare

--- a/packages/widget/src/domain/types/stake.ts
+++ b/packages/widget/src/domain/types/stake.ts
@@ -39,9 +39,19 @@ export const getInitialToken = (args: {
     .filter((val) => !!val.token)
     .chain((val) =>
       List.find(
-        (t) =>
-          (t.token.symbol === val.token && t.token.network === val.network) ||
-          tokenString(t.token) === val.token,
+        (t) => {
+          const tokenSymbolCompare =
+            val.token?.toLowerCase() === t.token.symbol.toLowerCase();
+
+          const tokenNetworkCompare =
+            val.network?.toLowerCase() === t.token.network.toLowerCase();
+
+          const tokenStringCompare = tokenString(t.token) === val.token;
+
+          return (
+            (tokenSymbolCompare && tokenNetworkCompare) || tokenStringCompare
+          );
+        },
         [...args.tokenBalances, ...args.defaultTokens]
       )
     )
@@ -85,7 +95,8 @@ export const canBeInitialYield = (args: {
   args.initQueryParams
     .chain((queryParams) =>
       Maybe.fromFalsy(
-        !!queryParams.yieldId && queryParams.yieldId === args.yieldDto.id
+        !!queryParams.yieldId &&
+          queryParams.yieldId.toLowerCase() === args.yieldDto.id.toLowerCase()
       )
     )
     .altLazy(() =>
@@ -120,7 +131,9 @@ export const getInitSelectedValidators = (args: {
     .chainNullable((params) => params.validator)
     .chain((initV) =>
       List.find(
-        (val) => val.name === initV || val.address === initV,
+        (val) =>
+          val.name?.toLowerCase() === initV.toLowerCase() ||
+          val.address === initV,
         args.yieldDto.validators
       )
     )


### PR DESCRIPTION
This pull request applies a patch to the `@stakekit/widget` package to improve how query parameters are compared by ensuring case-insensitive matching. The main changes update the logic for matching tokens, yield IDs, and validator names to use lowercase comparisons, which helps prevent issues caused by inconsistent casing in query parameters.

**Query parameter comparison improvements:**

* Updated token matching in `getInitialToken` to compare both token symbols and network names using lowercase, making the query parameter matching case-insensitive. (`packages/widget/src/domain/types/stake.ts`)
* Changed yield ID comparison in `canBeInitialYield` to use lowercase, ensuring yield IDs from query parameters are matched regardless of case. (`packages/widget/src/domain/types/stake.ts`)
* Modified validator name matching in `getInitSelectedValidators` to use lowercase for names, improving reliability when selecting validators via query parameters. (`packages/widget/src/domain/types/stake.ts`)

**Package metadata:**

* Added a patch changeset for `@stakekit/widget` describing the lowercase query param comparison fix. (`.changeset/honest-snakes-flash.md`)