### PR TITLE
fix: translation plurals

### DIFF
--- a/.changeset/beige-moments-burn.md
+++ b/.changeset/beige-moments-burn.md
@@ -2,4 +2,4 @@
 "@stakekit/widget": patch
 ---
 
-feat: validators config
+fix: translation plurals

--- a/.changeset/stupid-trams-give.md
+++ b/.changeset/stupid-trams-give.md
@@ -1,5 +1,0 @@
----
-"@stakekit/widget": patch
----
-
-feat: add hoodi icon

--- a/packages/widget/CHANGELOG.md
+++ b/packages/widget/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @stakekit/widget
 
+## 0.0.253
+
+### Patch Changes
+
+- 4d2ff10: feat: validators config
+- 7d2bc01: feat: add hoodi icon
+
 ## 0.0.252
 
 ### Patch Changes

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stakekit/widget",
-  "version": "0.0.252",
+  "version": "0.0.253",
   "type": "module",
   "main": "./dist/package/index.package.js",
   "types": "./dist/types/index.package.d.ts",

--- a/packages/widget/src/hooks/use-yield-meta-info.tsx
+++ b/packages/widget/src/hooks/use-yield-meta-info.tsx
@@ -110,7 +110,7 @@ export const useYieldMetaInfo = ({
           ) : null,
         lockupPeriod: y.metadata.lockupPeriod?.days
           ? t("details.lockup_period", {
-              days: y.metadata.lockupPeriod?.days,
+              count: y.metadata.lockupPeriod?.days,
             })
           : null,
         extra:
@@ -143,8 +143,8 @@ export const useYieldMetaInfo = ({
                   }),
             withdrawnTime:
               cooldownPeriodDays > 0
-                ? t("details.native_staking.unstake_time_days", {
-                    cooldownPeriodDays,
+                ? t("details.native_staking.unstake_time", {
+                    count: cooldownPeriodDays,
                   })
                 : t("details.native_staking.unstake_time_immediately"),
             withdrawnNotAvailable: null,
@@ -166,8 +166,8 @@ export const useYieldMetaInfo = ({
                 : t("details.lend.earn_interest_auto", { rewardSchedule }),
             withdrawnTime:
               cooldownPeriodDays > 0
-                ? t("details.lend.withdrawn_time_days", {
-                    cooldownPeriodDays,
+                ? t("details.lend.withdrawn_time", {
+                    count: cooldownPeriodDays,
                   })
                 : t("details.lend.withdrawn_time_immediately"),
             description: isCompound
@@ -203,7 +203,9 @@ export const useYieldMetaInfo = ({
                 : t("details.vault.earn_yield_auto", { rewardSchedule }),
             withdrawnTime:
               cooldownPeriodDays > 0
-                ? t("details.vault.withdrawn_time_days", { cooldownPeriodDays })
+                ? t("details.vault.withdrawn_time", {
+                    count: cooldownPeriodDays,
+                  })
                 : t("details.vault.withdrawn_time_immediately"),
             withdrawnNotAvailable: null,
             ...def,
@@ -231,14 +233,16 @@ export const useYieldMetaInfo = ({
                   }),
             withdrawnTime: y.status.exit
               ? cooldownPeriodDays > 0
-                ? t("details.liquid_stake.unstake_time_days", {
-                    cooldownPeriodDays,
-                    claimDays: y.metadata.withdrawPeriod?.days ?? 0,
-                    context:
-                      (y.metadata.withdrawPeriod?.days ?? 0) > 0
-                        ? "with_claim_days"
-                        : undefined,
-                  })
+                ? (y.metadata.withdrawPeriod?.days ?? 0) > 0
+                  ? t("details.liquid_stake.unstake_time_days_with_claim", {
+                      unstakeTime: t("details.liquid_stake.unstake_time", {
+                        count: cooldownPeriodDays,
+                      }),
+                      count: y.metadata.withdrawPeriod?.days,
+                    })
+                  : t("details.liquid_stake.unstake_time", {
+                      count: cooldownPeriodDays,
+                    })
                 : t("details.liquid_stake.unstake_time_immediately")
               : null,
             withdrawnNotAvailable: !y.status.exit
@@ -263,16 +267,12 @@ export const useYieldMetaInfo = ({
                 : null,
             earnRewards:
               rewardClaiming === "manual"
-                ? t("details.restake.earn_rewards_manual", {
-                    rewardSchedule,
-                  })
-                : t("details.restake.earn_rewards_auto", {
-                    rewardSchedule,
-                  }),
+                ? t("details.restake.earn_rewards_manual", { rewardSchedule })
+                : t("details.restake.earn_rewards_auto", { rewardSchedule }),
             withdrawnTime: y.status.exit
               ? cooldownPeriodDays > 0
-                ? t("details.restake.unstake_time_days", {
-                    cooldownPeriodDays,
+                ? t("details.restake.unstake_time", {
+                    count: cooldownPeriodDays,
                   })
                 : t("details.restake.unstake_time_immediately")
               : null,

--- a/packages/widget/src/translation/English/translations.json
+++ b/packages/widget/src/translation/English/translations.json
@@ -72,14 +72,16 @@
     "campaign_susd_position_locked": "The position is locked until April 20, 2026. <link0>Learn more</link0>",
     "campaign_susd": "Learn more about sUSD staking program <link0>here</link0>",
     "campaign": "Rewards are locked until 28 May 2026. Early withdrawals may incur penalties. <link0>Learn more</link0>",
-    "lockup_period": "Minimum lock up time is {{days}} days",
+    "lockup_period_one": "Minimum lock up time is {{count}} day",
+    "lockup_period_other": "Minimum lock up time is {{count}} days",
     "native_staking": {
       "earn_after_warmup_one": "You'll start earning {{count}} day after you supply your assets",
       "earn_after_warmup_other": "You'll start earning {{count}} days after you supply your assets",
       "earn_rewards_auto": "Earned rewards are distributed each {{rewardSchedule}} and accrue to your position automatically",
       "earn_rewards_manual": "Earned rewards are distributed each {{rewardSchedule}} and need to be claimed manually. Your earnings compound, if you claim and restake quickly",
       "unstake_time_immediately": "When unstaking, your assets will be available immediately",
-      "unstake_time_days": "When unstaking it takes {{cooldownPeriodDays}} days for your tokens to be available"
+      "unstake_time_one": "When unstaking it takes {{count}} day for your tokens to be available",
+      "unstake_time_other": "When unstaking it takes {{count}} days for your tokens to be available"
     },
     "vault": {
       "description": "When you deposit {{stakeToken}} you'll receive {{depositToken}}. You can trade this liquid asset at any time",
@@ -89,7 +91,8 @@
       "earn_yield_auto": "Earned yield is updated each {{rewardSchedule}} and accrues automatically",
       "earn_yield_manual": "Earned yield is updated each {{rewardSchedule}} and needs to be claimed manually",
       "withdrawn_time_immediately": "When withdrawing, your assets will be available immediately",
-      "withdrawn_time_days": "When withdrawing it takes {{cooldownPeriodDays}} days for your assets will be available"
+      "withdrawn_time_one": "When withdrawing it takes {{count}} day for your assets will be available",
+      "withdrawn_time_other": "When withdrawing it takes {{count}} days for your assets will be available"
     },
     "lend": {
       "description": "When you supply {{stakeToken}} you'll receive {{rewardTokens}}. You can borrow against the supplied assets on {{providerName}}",
@@ -99,7 +102,8 @@
       "earn_interest_auto": "Earned interest is distributed each {{rewardSchedule}} and accrues automatically",
       "earn_interest_manual": "Earned interest is distributed each {{rewardSchedule}} and needs to be claimed manually",
       "withdrawn_time_immediately": "Upon withdrawing, your assets will be available immediately",
-      "withdrawn_time_days": "After withdrawing, your assets will be available in {{cooldownPeriodDays}} days"
+      "withdrawn_time_one": "After withdrawing, your assets will be available in {{count}} day",
+      "withdrawn_time_other": "After withdrawing, your assets will be available in {{count}} days"
     },
     "liquid_stake": {
       "description": "When you liquid stake {{stakeToken}} you'll receive {{rewardTokens}}. You can trade this liquid asset at any time",
@@ -108,8 +112,10 @@
       "earn_rewards_auto": "Earned rewards are distributed each {{rewardSchedule}} and accrue to your position automatically",
       "earn_rewards_manual": "Earned rewards are distributed each {{rewardSchedule}} and need to be claimed manually",
       "unstake_time_immediately": "When unstaking, your assets will be available immediately",
-      "unstake_time_days": "When unstaking it takes {{cooldownPeriodDays}} days for your tokens to be available",
-      "unstake_time_days_with_claim_days": "When unstaking it takes {{cooldownPeriodDays}} days for your tokens to be available. They need to be claimed within {{claimDays}} days, otherwise they'll need to be staked again.",
+      "unstake_time_one": "When unstaking it takes {{count}} day for your tokens to be available",
+      "unstake_time_other": "When unstaking it takes {{count}} days for your tokens to be available",
+      "unstake_time_days_with_claim_one": "{{unstakeTime}}. They need to be claimed within {{count}} day, otherwise they'll need to be staked again.",
+      "unstake_time_days_with_claim_other": "{{unstakeTime}}. They need to be claimed within {{count}} days, otherwise they'll need to be staked again.",
       "withdrawn_not_available": "Withdrawals aren't available at the moment. To exit your position you can sell {{rewardTokens}} any time on DEXs"
     },
     "restake": {
@@ -119,7 +125,8 @@
       "earn_rewards_auto": "Earned rewards are distributed each {{rewardSchedule}} and accrue to your position automatically",
       "earn_rewards_manual": "Earned rewards are distributed each {{rewardSchedule}} and need to be claimed manually",
       "unstake_time_immediately": "When unstaking, your assets will be available immediately",
-      "unstake_time_days": "When unstaking it takes {{cooldownPeriodDays}} days for your tokens to be available",
+      "unstake_time_one": "When unstaking it takes {{count}} day for your tokens to be available",
+      "unstake_time_other": "When unstaking it takes {{count}} days for your tokens to be available",
       "withdrawn_not_available": "Withdrawals aren't available at the moment. To exit your position you can sell {{rewardTokens}} any time on DEXs"
     },
     "extra_tezos": "You can use or send staked XTZ as normal",

--- a/packages/widget/src/translation/French/translations.json
+++ b/packages/widget/src/translation/French/translations.json
@@ -72,14 +72,16 @@
     "campaign_susd_position_locked": "La position est bloquée jusqu'au 20 avril 2026. <link0>En savoir plus</link0>",
     "campaign_susd": "En savoir plus sur le programme de staking sUSD <link0>ici</link0>",
     "campaign": "Les récompenses sont bloquées jusqu'au 28 mai 2026. Les retraits anticipés peuvent entraîner des pénalités. <link0>En savoir plus</link0>",
-    "lockup_period": "La période de blocage minimum est de {{days}} jours",
+    "lockup_period_one": "La période de blocage minimum est de {{count}} jour",
+    "lockup_period_other": "La période de blocage minimum est de {{count}} jours",
     "native_staking": {
       "earn_after_warmup_one": "Vous commencerez à être récompensé {{count}} jour après avoir fourni vos actifs",
       "earn_after_warmup_other": "Vous commencerez à être récompensé {{count}} jours après avoir fourni vos actifs",
       "earn_rewards_auto": "Les récompenses gagnées sont distribuées chaque {{rewardSchedule}} et cumulées à votre position automatiquement",
       "earn_rewards_manual": "Les récompenses gagnées sont distribuées chaque {{rewardSchedule}} et doivent être réclamées manuellement. Vos gains se cumulent, si vous les réclamez et restakez rapidement",
       "unstake_time_immediately": "En les déstakant, vos actifs seront disponibles immédiatement",
-      "unstake_time_days": "En les déstakant, vos tokens seront disponibles sous {{cooldownPeriodDays}} jours"
+      "unstake_time_one": "En les déstakant, il faut {{count}} jour pour que vos tokens soient disponibles",
+      "unstake_time_other": "En les déstakant, il faut {{count}} jours pour que vos tokens soient disponibles"
     },
     "vault": {
       "description": "En déposant du {{stakeToken}} vous recevrez du {{depositToken}}. Vous pouvez trader cet actif liquide à tout moment",
@@ -89,7 +91,8 @@
       "earn_yield_auto": "Le yield gagné est mis à jour chaque {{rewardSchedule}} et se cumule automatiquement",
       "earn_yield_manual": "Le yield gagné est mis à jour chaque {{rewardSchedule}} et doit être réclamé manuellement",
       "withdrawn_time_immediately": "En les retirant, vos actifs seront disponibles immédiatement",
-      "withdrawn_time_days": "En les retirant, vos actifs seront disponibles sous {{cooldownPeriodDays}} jours"
+      "withdrawn_time_one": "En les retirant, il faut {{count}} jour pour que vos actifs soient disponibles",
+      "withdrawn_time_other": "En les retirant, il faut {{count}} jours pour que vos actifs soient disponibles"
     },
     "lend": {
       "description": "En fournissant du {{stakeToken}} vous recevrez des {{rewardTokens}}. Vous pouvez emprunter contre les actifs fournis sur {{providerName}}",
@@ -99,7 +102,8 @@
       "earn_interest_auto": "Les intérêts gagnés sont distribués chaque {{rewardSchedule}} et se cumulent automatiquement",
       "earn_interest_manual": "Les intérêts gagnés sont distribués chaque {{rewardSchedule}} et doivent être réclamés manuellement",
       "withdrawn_time_immediately": "En les retirant, vos actifs seront disponibles immédiatement",
-      "withdrawn_time_days": "Après leur retrait, vos actifs seront disponibles sous {{cooldownPeriodDays}} jours"
+      "withdrawn_time_one": "Après leur retrait, vos actifs seront disponibles sous {{count}} jour",
+      "withdrawn_time_other": "Après leur retrait, vos actifs seront disponibles sous {{count}} jours"
     },
     "liquid_stake": {
       "description": "En stakant du {{stakeToken}} vous recevrez des {{rewardTokens}}. Vous pouvez trader cet actif liquide à tout moment",
@@ -108,8 +112,10 @@
       "earn_rewards_auto": "Les récompenses gagnées sont distribuées chaque {{rewardSchedule}} et cumulées à votre position automatiquement",
       "earn_rewards_manual": "Les récompenses gagnées sont distribuées chaque {{rewardSchedule}} et doivent être réclamées manuellement",
       "unstake_time_immediately": "En les déstakant, vos actifs seront disponibles immédiatement",
-      "unstake_time_days": "En les déstakant, vos tokens seront disponibles sous {{cooldownPeriodDays}} jours",
-      "unstake_time_days_with_claim_days": "En les déstakant, vos tokens seront disponibles sous {{cooldownPeriodDays}} jours. Vous devez les réclamer sous {{claimDays}} jours, sans quoi il faudra les staker à nouveau.",
+      "unstake_time_one": "En les déstakant, il faut {{count}} jour pour que vos tokens soient disponibles",
+      "unstake_time_other": "En les déstakant, il faut {{count}} jours pour que vos tokens soient disponibles",
+      "unstake_time_days_with_claim_one": "{{unstakeTime}}. Ils doivent être réclamés sous {{count}} jour, sans quoi il faudra les staker à nouveau.",
+      "unstake_time_days_with_claim_other": "{{unstakeTime}}. Ils doivent être réclamés sous {{count}} jours, sans quoi il faudra les staker à nouveau.",
       "withdrawn_not_available": "Les retraits ne sont pas disponibles pour le moment. Pour liquider votre position, vous pouvez vendre {{rewardTokens}} à tout moment sur les DEXs"
     },
     "restake": {
@@ -119,7 +125,8 @@
       "earn_rewards_auto": "Les récompenses gagnées sont distribuées chaque {{rewardSchedule}} et cumulées à votre position automatiquement",
       "earn_rewards_manual": "Les récompenses gagnées sont distribuées chaque {{rewardSchedule}} et doivent être réclamées manuellement",
       "unstake_time_immediately": "En les déstakant, vos actifs seront disponibles immédiatement",
-      "unstake_time_days": "En les déstakant, vos tokens seront disponibles sous {{cooldownPeriodDays}} jours",
+      "unstake_time_one": "En les déstakant, il faut {{count}} jour pour que vos tokens soient disponibles",
+      "unstake_time_other": "En les déstakant, il faut {{count}} jours pour que vos tokens soient disponibles",
       "withdrawn_not_available": "Les retraits ne sont pas disponibles pour le moment. Pour liquider votre position, vous pouvez vendre {{rewardTokens}} à tout moment sur les DEXs"
     },
     "extra_tezos": "Vous pouvez utiliser ou envoyer des XTZ stakés normalement",


### PR DESCRIPTION
This pull request addresses translation pluralization issues in the StakeKit widget, ensuring that time-related messages (like days vs. day) are correctly localized in both English and French. The main changes include updating translation keys and values to support proper plural forms and adjusting code to use the new keys.

**Translation improvements:**

* Updated English translation keys and values in `translations.json` to support singular and plural forms for time-related messages (e.g., `unstake_time_one`, `unstake_time_other`), replacing previous generic plural keys. [[1]](diffhunk://#diff-03e4300a83b5314907bdf527e51e924c1e6e188f2de3933897eefcabcabf63f5L75-R84) [[2]](diffhunk://#diff-03e4300a83b5314907bdf527e51e924c1e6e188f2de3933897eefcabcabf63f5L92-R95) [[3]](diffhunk://#diff-03e4300a83b5314907bdf527e51e924c1e6e188f2de3933897eefcabcabf63f5L102-R106) [[4]](diffhunk://#diff-03e4300a83b5314907bdf527e51e924c1e6e188f2de3933897eefcabcabf63f5L111-R118) [[5]](diffhunk://#diff-03e4300a83b5314907bdf527e51e924c1e6e188f2de3933897eefcabcabf63f5L122-R129)
* Updated French translation keys and values in `translations.json` to match the new pluralization structure, ensuring correct singular/plural usage for time messages. [[1]](diffhunk://#diff-9d9375225e9443bc819ea8c420239c9b987bb27b83903b204066f34b91633fb4L75-R84) [[2]](diffhunk://#diff-9d9375225e9443bc819ea8c420239c9b987bb27b83903b204066f34b91633fb4L92-R95) [[3]](diffhunk://#diff-9d9375225e9443bc819ea8c420239c9b987bb27b83903b204066f34b91633fb4L102-R106) [[4]](diffhunk://#diff-9d9375225e9443bc819ea8c420239c9b987bb27b83903b204066f34b91633fb4L111-R118) [[5]](diffhunk://#diff-9d9375225e9443bc819ea8c420239c9b987bb27b83903b204066f34b91633fb4L122-R129)

**Code changes for translation keys:**

* Refactored usages of translation keys in `use-yield-meta-info.tsx` to use the new pluralization-aware keys (e.g., `unstake_time`, `withdrawn_time`) instead of the old `_days` keys. [[1]](diffhunk://#diff-42d7792f511c219fd70c8f5a813a42efd6ef31b615e04dbc7e54698acb59ae58L146-R146) [[2]](diffhunk://#diff-42d7792f511c219fd70c8f5a813a42efd6ef31b615e04dbc7e54698acb59ae58L169-R169) [[3]](diffhunk://#diff-42d7792f511c219fd70c8f5a813a42efd6ef31b615e04dbc7e54698acb59ae58L206-R206) [[4]](diffhunk://#diff-42d7792f511c219fd70c8f5a813a42efd6ef31b615e04dbc7e54698acb59ae58L234-R234) [[5]](diffhunk://#diff-42d7792f511c219fd70c8f5a813a42efd6ef31b615e04dbc7e54698acb59ae58L266-R270)

**Other translation enhancements:**

* Updated French translation for the terms of use link to use a proper link element instead of plain text.

**Meta changes:**

* Added a patch-level changeset entry for `@stakekit/widget` describing the translation plural fixes. (.changeset/beige-moments-burn.md)