### PR TITLE
fix: tests

### DIFF
--- a/packages/widget/src/providers/misc/config.ts
+++ b/packages/widget/src/providers/misc/config.ts
@@ -50,15 +50,16 @@ const queryFn = async ({
           v.getTronConnectors({ forceWalletConnectOnly })
         )
     ),
-    MaybeAsync.liftMaybe(Maybe.fromFalsy(filteredMiscChainsMap.solana)).chain(
-      () =>
-        MaybeAsync(() => import("./solana-connector")).map((v) =>
-          v.getSolanaConnectors({
-            forceWalletConnectOnly,
-            wallets: solanaWallets,
-            connection: solanaConnection,
-          })
-        )
+    MaybeAsync.liftMaybe(
+      Maybe.fromFalsy(filteredMiscChainsMap.solana && !config.env.isTestMode)
+    ).chain(() =>
+      MaybeAsync(() => import("./solana-connector")).map((v) =>
+        v.getSolanaConnectors({
+          forceWalletConnectOnly,
+          wallets: solanaWallets,
+          connection: solanaConnection,
+        })
+      )
     ),
   ]).then((connectors) => ({
     miscChainsMap: filteredMiscChainsMap,

--- a/packages/widget/src/providers/solana/index.tsx
+++ b/packages/widget/src/providers/solana/index.tsx
@@ -1,7 +1,4 @@
-import {
-  type Adapter,
-  WalletAdapterNetwork,
-} from "@solana/wallet-adapter-base";
+import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
 import {
   ConnectionProvider,
   WalletProvider,
@@ -10,30 +7,26 @@ import {
   BitgetWalletAdapter,
   PhantomWalletAdapter,
   TrustWalletAdapter,
-  // WalletConnectWalletAdapter,
 } from "@solana/wallet-adapter-wallets";
 import { clusterApiUrl } from "@solana/web3.js";
-import type { PropsWithChildren } from "react";
-
-// import { config } from "../../config";
+import { type PropsWithChildren, useMemo } from "react";
+import { config } from "../../config";
 
 const network = WalletAdapterNetwork.Mainnet;
 
 const endpoint = clusterApiUrl(network);
 
-const wallets: Adapter[] = [
-  new PhantomWalletAdapter(),
-  new BitgetWalletAdapter(),
-  new TrustWalletAdapter(),
-  // new WalletConnectWalletAdapter({
-  //   network,
-  //   options: {
-  //     projectId: config.walletConnectV2.projectId,
-  //   },
-  // }),
-];
-
 export const SolanaProvider = ({ children }: PropsWithChildren) => {
+  const wallets = useMemo(() => {
+    return config.env.isTestMode
+      ? []
+      : [
+          new PhantomWalletAdapter(),
+          new BitgetWalletAdapter(),
+          new TrustWalletAdapter(),
+        ];
+  }, []);
+
   return (
     <ConnectionProvider endpoint={endpoint}>
       <WalletProvider wallets={wallets}>{children}</WalletProvider>


### PR DESCRIPTION
This pull request updates the Solana wallet provider logic to improve test mode handling and simplify imports. The main change ensures that Solana wallet adapters are not loaded when the app is running in test mode, which helps prevent unnecessary dependencies and side effects during testing. Additionally, the imports are cleaned up for clarity.

**Test mode handling improvements:**

* The Solana wallet adapters (`PhantomWalletAdapter`, `BitgetWalletAdapter`, `TrustWalletAdapter`) are now conditionally loaded only when not in test mode, using the `config.env.isTestMode` flag in `SolanaProvider`. In test mode, the wallet list is empty.
* The dynamic import logic for Solana connectors in `config.ts` now checks that the app is not in test mode before attempting to load Solana connectors.

**Code cleanup:**

* Unused imports and commented-out code related to Solana adapters and React props are removed for clarity in `index.tsx`.