### PR TITLE
fix: portal container

### DIFF
--- a/.changeset/spotty-insects-jog.md
+++ b/.changeset/spotty-insects-jog.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+fix: portal container

--- a/packages/widget/src/components/atoms/dropdown/index.tsx
+++ b/packages/widget/src/components/atoms/dropdown/index.tsx
@@ -1,5 +1,6 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Fragment } from "react";
+import { useSettings } from "../../../providers/settings";
 import { id } from "../../../styles/theme/ids";
 import { Box } from "../box";
 import { CaretDownIcon } from "../icons/caret-down";
@@ -27,6 +28,8 @@ export function Dropdown<T extends { label: string; value: string }>({
   placeholder,
   isError,
 }: DropdownProps<T>) {
+  const { portalContainer } = useSettings();
+
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>
@@ -46,7 +49,7 @@ export function Dropdown<T extends { label: string; value: string }>({
         </Box>
       </DropdownMenu.Trigger>
 
-      <DropdownMenu.Portal>
+      <DropdownMenu.Portal container={portalContainer}>
         <Box data-rk={id}>
           <DropdownMenu.Content className={dropdownContent} sideOffset={3}>
             <DropdownMenu.RadioGroup

--- a/packages/widget/src/components/atoms/tooltip/index.tsx
+++ b/packages/widget/src/components/atoms/tooltip/index.tsx
@@ -1,5 +1,6 @@
 import * as Tooltip from "@radix-ui/react-tooltip";
 import type { PropsWithChildren, ReactNode } from "react";
+import { useSettings } from "../../../providers/settings";
 import { id } from "../../../styles/theme/ids";
 import { Text } from "../typography/text";
 import { tooltipContent, triggerWrapper } from "./style.css";
@@ -15,29 +16,33 @@ export const ToolTip = ({
   maxWidth?: number;
   textAlign?: "center" | "left" | "right" | "end";
   asChild?: boolean;
-}>) => (
-  <Tooltip.Provider>
-    <Tooltip.Root delayDuration={0}>
-      <Tooltip.Trigger className={triggerWrapper} asChild={asChild}>
-        {children}
-      </Tooltip.Trigger>
-      <Tooltip.Portal>
-        <Tooltip.Content
-          className={tooltipContent}
-          style={{ maxWidth }}
-          sideOffset={5}
-          data-rk={id}
-        >
-          {typeof label === "string" ? (
-            <Text textAlign={textAlign} variant={{ type: "white" }}>
-              {label}
-            </Text>
-          ) : (
-            label
-          )}
-          <Tooltip.Arrow />
-        </Tooltip.Content>
-      </Tooltip.Portal>
-    </Tooltip.Root>
-  </Tooltip.Provider>
-);
+}>) => {
+  const { portalContainer } = useSettings();
+
+  return (
+    <Tooltip.Provider>
+      <Tooltip.Root delayDuration={0}>
+        <Tooltip.Trigger className={triggerWrapper} asChild={asChild}>
+          {children}
+        </Tooltip.Trigger>
+        <Tooltip.Portal container={portalContainer}>
+          <Tooltip.Content
+            className={tooltipContent}
+            style={{ maxWidth }}
+            sideOffset={5}
+            data-rk={id}
+          >
+            {typeof label === "string" ? (
+              <Text textAlign={textAlign} variant={{ type: "white" }}>
+                {label}
+              </Text>
+            ) : (
+              label
+            )}
+            <Tooltip.Arrow />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+};


### PR DESCRIPTION
This pull request introduces a patch to `@stakekit/widget` to fix issues with the portal container for dropdowns and tooltips. The main improvement is ensuring that dropdown and tooltip menus are rendered in the correct DOM container, resolving potential display or positioning problems.

**Portal container handling:**

* Updated the `Dropdown` component in `packages/widget/src/components/atoms/dropdown/index.tsx` to use the `portalContainer` from settings, passing it to `DropdownMenu.Portal` for proper menu rendering. [[1]](diffhunk://#diff-d3812b37bbeda0012df03d0a90cf83205688ad6d064f0136c637a1c6a4f606b7R3) [[2]](diffhunk://#diff-d3812b37bbeda0012df03d0a90cf83205688ad6d064f0136c637a1c6a4f606b7R31-R32) [[3]](diffhunk://#diff-d3812b37bbeda0012df03d0a90cf83205688ad6d064f0136c637a1c6a4f606b7L49-R52)
* Updated the `ToolTip` component in `packages/widget/src/components/atoms/tooltip/index.tsx` to use the `portalContainer` from settings, passing it to `Tooltip.Portal` for correct tooltip placement. [[1]](diffhunk://#diff-c34c392bafdee10519c31ce26630bcad25a91f02b246f0b7783f02fd566e20abR3) [[2]](diffhunk://#diff-c34c392bafdee10519c31ce26630bcad25a91f02b246f0b7783f02fd566e20abL18-R28) [[3]](diffhunk://#diff-c34c392bafdee10519c31ce26630bcad25a91f02b246f0b7783f02fd566e20abR48)

**Release note:**

* Added a patch changeset describing the fix for the portal container in `.changeset/spotty-insects-jog.md`.