### PR TITLE
fix: token equals

### DIFF
--- a/.changeset/three-beers-argue.md
+++ b/.changeset/three-beers-argue.md
@@ -1,0 +1,5 @@
+---
+"@stakekit/widget": patch
+---
+
+fix: token equals

--- a/packages/widget/src/domain/index.ts
+++ b/packages/widget/src/domain/index.ts
@@ -19,7 +19,7 @@ export const tokenString = (token: TokenDto): TokenString => {
 };
 
 export const equalTokens = (a: TokenDto, b: TokenDto) =>
-  tokenString(a) === tokenString(b);
+  tokenString(a) === tokenString(b) && a.symbol === b.symbol;
 
 export const stakeTokenSameAsGasToken = ({
   stakeToken,


### PR DESCRIPTION
This pull request introduces a patch to the `@stakekit/widget` package to fix the token comparison logic. The main change ensures that token equality checks now also compare the `symbol` property, making token comparisons more accurate.

Token comparison logic improvements:

* Updated the `equalTokens` function in `packages/widget/src/domain/index.ts` to require both the string representation and the `symbol` property to match when determining token equality.

Release notes:

* Added a changeset file `.changeset/three-beers-argue.md` documenting the patch and the fix for token equality.