### PR TITLE
fix(widget): clean up icon fallbacks and pending action labels

### DIFF
--- a/packages/widget/src/components/atoms/image/index.tsx
+++ b/packages/widget/src/components/atoms/image/index.tsx
@@ -1,6 +1,5 @@
 import type { HTMLProps } from "react";
 import { useMemo } from "react";
-import { getBackgroundColor } from "../../../utils";
 import type { BoxProps } from "../box";
 import { Box } from "../box";
 
@@ -53,9 +52,8 @@ const createMonogramImageSrc = (name?: string) => {
   if (!firstCharacter) return undefined;
 
   const initial = escapeForSvg(firstCharacter.toUpperCase());
-  const backgroundColor = getBackgroundColor(name);
 
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100"><circle cx="50" cy="50" r="50" fill="${backgroundColor}" /><text x="50" y="50" fill="#FFFFFF" font-family="Arial, sans-serif" font-size="48" font-weight="700" text-anchor="middle" dominant-baseline="central">${initial}</text></svg>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100"><circle cx="50" cy="50" r="49" fill="#FFFFFF" stroke="rgba(0,0,0,0.08)" stroke-width="2" /><text x="50" y="50" fill="#000000" font-family="Arial, sans-serif" font-size="48" font-weight="700" text-anchor="middle" dominant-baseline="central">${initial}</text></svg>`;
 
   return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
 };

--- a/packages/widget/src/components/atoms/token-icon/index.tsx
+++ b/packages/widget/src/components/atoms/token-icon/index.tsx
@@ -38,6 +38,7 @@ export const TokenIcon = ({
           {!hideNetwork && !hideNetworkLogo && (
             <NetworkLogoImage
               networkLogoUri={networkLogoUri}
+              networkName={token.network}
               tokenNetworkLogoHw={tokenNetworkLogoHw}
             />
           )}

--- a/packages/widget/src/components/atoms/token-icon/network-icon-image/index.tsx
+++ b/packages/widget/src/components/atoms/token-icon/network-icon-image/index.tsx
@@ -1,22 +1,70 @@
+import { useState } from "react";
 import type { Atoms } from "../../../../styles/theme/atoms.css";
 import { Box } from "../../box";
 import { Image } from "../../image";
-import { logoContainer, logoImage } from "./style.css";
+import { fallbackContainer, logoContainer, logoImage } from "./style.css";
 
 type NetworkLogoImageProps = {
   networkLogoUri: string;
+  networkName?: string;
   tokenNetworkLogoHw?: Atoms["hw"];
 };
 
 export const NetworkLogoImage = ({
   networkLogoUri,
+  networkName,
   tokenNetworkLogoHw = "3",
-}: NetworkLogoImageProps) => (
-  <Box className={logoContainer} data-rk="token-network-logo">
-    <Image
-      src={networkLogoUri}
-      wrapperProps={{ hw: tokenNetworkLogoHw }}
-      imgProps={{ hw: tokenNetworkLogoHw, className: logoImage }}
-    />
-  </Box>
+}: NetworkLogoImageProps) => {
+  const [erroredUri, setErroredUri] = useState<string | null>(null);
+
+  const hasError = erroredUri === networkLogoUri;
+
+  if (!networkLogoUri || hasError) {
+    const initial = networkName?.trim()?.[0]?.toUpperCase() ?? "?";
+
+    return (
+      <Box className={fallbackContainer} data-rk="token-network-logo-fallback">
+        <Box hw={tokenNetworkLogoHw} display="flex">
+          <ChainInitial initial={initial} />
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box className={logoContainer} data-rk="token-network-logo">
+      <Image
+        src={networkLogoUri}
+        wrapperProps={{ hw: tokenNetworkLogoHw }}
+        imgProps={{
+          hw: tokenNetworkLogoHw,
+          className: logoImage,
+          onError: () => setErroredUri(networkLogoUri),
+        }}
+      />
+    </Box>
+  );
+};
+
+const ChainInitial = ({ initial }: { initial: string }) => (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 100 100"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <text
+      x="50"
+      y="52"
+      fill="#fff"
+      fontFamily="Arial, sans-serif"
+      fontSize="64"
+      fontWeight="700"
+      textAnchor="middle"
+      dominantBaseline="central"
+    >
+      {initial}
+    </text>
+  </svg>
 );

--- a/packages/widget/src/components/atoms/token-icon/network-icon-image/index.tsx
+++ b/packages/widget/src/components/atoms/token-icon/network-icon-image/index.tsx
@@ -1,8 +1,7 @@
-import { useState } from "react";
 import type { Atoms } from "../../../../styles/theme/atoms.css";
 import { Box } from "../../box";
 import { Image } from "../../image";
-import { fallbackContainer, logoContainer, logoImage } from "./style.css";
+import { logoContainer, logoImage } from "./style.css";
 
 type NetworkLogoImageProps = {
   networkLogoUri: string;
@@ -14,57 +13,13 @@ export const NetworkLogoImage = ({
   networkLogoUri,
   networkName,
   tokenNetworkLogoHw = "3",
-}: NetworkLogoImageProps) => {
-  const [erroredUri, setErroredUri] = useState<string | null>(null);
-
-  const hasError = erroredUri === networkLogoUri;
-
-  if (!networkLogoUri || hasError) {
-    const initial = networkName?.trim()?.[0]?.toUpperCase() ?? "?";
-
-    return (
-      <Box className={fallbackContainer} data-rk="token-network-logo-fallback">
-        <Box hw={tokenNetworkLogoHw} display="flex">
-          <ChainInitial initial={initial} />
-        </Box>
-      </Box>
-    );
-  }
-
-  return (
-    <Box className={logoContainer} data-rk="token-network-logo">
-      <Image
-        src={networkLogoUri}
-        wrapperProps={{ hw: tokenNetworkLogoHw }}
-        imgProps={{
-          hw: tokenNetworkLogoHw,
-          className: logoImage,
-          onError: () => setErroredUri(networkLogoUri),
-        }}
-      />
-    </Box>
-  );
-};
-
-const ChainInitial = ({ initial }: { initial: string }) => (
-  <svg
-    width="100%"
-    height="100%"
-    viewBox="0 0 100 100"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <text
-      x="50"
-      y="52"
-      fill="#fff"
-      fontFamily="Arial, sans-serif"
-      fontSize="64"
-      fontWeight="700"
-      textAnchor="middle"
-      dominantBaseline="central"
-    >
-      {initial}
-    </text>
-  </svg>
+}: NetworkLogoImageProps) => (
+  <Box className={logoContainer} data-rk="token-network-logo">
+    <Image
+      src={networkLogoUri}
+      fallbackName={networkName}
+      wrapperProps={{ hw: tokenNetworkLogoHw }}
+      imgProps={{ hw: tokenNetworkLogoHw, className: logoImage }}
+    />
+  </Box>
 );

--- a/packages/widget/src/components/atoms/token-icon/network-icon-image/style.css.ts
+++ b/packages/widget/src/components/atoms/token-icon/network-icon-image/style.css.ts
@@ -1,15 +1,25 @@
 import { style } from "@vanilla-extract/css";
 
-export const logoContainer = style({
+const baseContainer = {
   position: "absolute",
   bottom: -2,
   right: -2,
   borderRadius: "50%",
-  padding: "4px",
-  backgroundColor: "rgba(37,37,37, 0.95)",
+  padding: "3px",
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
+} as const;
+
+export const logoContainer = style({
+  ...baseContainer,
+  backgroundColor: "#ffffff",
+  boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.06)",
+});
+
+export const fallbackContainer = style({
+  ...baseContainer,
+  backgroundColor: "#9ca3af",
 });
 
 export const logoImage = style({

--- a/packages/widget/src/components/atoms/token-icon/network-icon-image/style.css.ts
+++ b/packages/widget/src/components/atoms/token-icon/network-icon-image/style.css.ts
@@ -1,6 +1,6 @@
 import { style } from "@vanilla-extract/css";
 
-const baseContainer = {
+const baseContainer = style({
   position: "absolute",
   bottom: -2,
   right: -2,
@@ -9,18 +9,15 @@ const baseContainer = {
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-} as const;
-
-export const logoContainer = style({
-  ...baseContainer,
-  backgroundColor: "#ffffff",
-  boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.06)",
 });
 
-export const fallbackContainer = style({
-  ...baseContainer,
-  backgroundColor: "#9ca3af",
-});
+export const logoContainer = style([
+  baseContainer,
+  {
+    backgroundColor: "#ffffff",
+    boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.06)",
+  },
+]);
 
 export const logoImage = style({
   maxWidth: "100%",

--- a/packages/widget/src/components/atoms/token-icon/provider-icon/index.tsx
+++ b/packages/widget/src/components/atoms/token-icon/provider-icon/index.tsx
@@ -38,6 +38,7 @@ export const ProviderIcon = ({
           {!hideNetwork && !hideNetworkLogo && (
             <NetworkLogoImage
               networkLogoUri={mainUrl || networkLogoUri}
+              networkName={token.network}
               tokenNetworkLogoHw={tokenNetworkLogoHw}
             />
           )}

--- a/packages/widget/src/components/molecules/reward-token-details/index.tsx
+++ b/packages/widget/src/components/molecules/reward-token-details/index.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from "react";
 import { Trans } from "react-i18next";
 import type { YieldPendingActionType } from "../../../domain/types/pending-action";
 import type { useRewardTokenDetails } from "../../../hooks/use-reward-token-details";
+import { humanizePendingActionType } from "../../../utils/formatters";
 import { Box } from "../../atoms/box";
 import { MorphoStarsIcon } from "../../atoms/icons/morpho-stars";
 import { Image } from "../../atoms/image";
@@ -35,6 +36,11 @@ export const RewardTokenDetails = ({
     return "unstake_review.unstake_from";
   })();
 
+  const i18nDefaults =
+    rest.type === "pendingAction"
+      ? humanizePendingActionType(rest.pendingAction)
+      : undefined;
+
   return rewardToken
     .map((rt) => {
       return (
@@ -66,6 +72,7 @@ export const RewardTokenDetails = ({
           <Text variant={{ weight: "semibold" }}>
             <Trans
               i18nKey={i18nKey}
+              defaults={i18nDefaults}
               values={{ providerName: rt.providerName }}
               components={{
                 symbols1: (

--- a/packages/widget/src/pages-dashboard/position-details/components/position-details-actions.tsx
+++ b/packages/widget/src/pages-dashboard/position-details/components/position-details-actions.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../../pages/position-details/components/amount-block";
 import { StaticActionBlock } from "../../../pages/position-details/components/static-action-block";
 import { usePositionDetails } from "../../../pages/position-details/hooks/use-position-details";
+import { humanizePendingActionType } from "../../../utils/formatters";
 import { PositionDetailsActionTabs } from "./position-details-action-tabs";
 import { container } from "./styles.css";
 
@@ -170,7 +171,12 @@ export const PositionDetailsActions = () => {
                     label={t(
                       `position_details.pending_action_button.${
                         val.pendingActionDto.type.toLowerCase() as Lowercase<YieldPendingActionType>
-                      }`
+                      }`,
+                      {
+                        defaultValue: humanizePendingActionType(
+                          val.pendingActionDto.type
+                        ),
+                      }
                     )}
                     onMaxClick={null}
                     formattedAmount={val.formattedAmount}

--- a/packages/widget/src/pages-dashboard/position-details/position-details-model.tsx
+++ b/packages/widget/src/pages-dashboard/position-details/position-details-model.tsx
@@ -419,13 +419,7 @@ const getStatusSummary = ({
         pendingAction.pendingActionDto.type === "CLAIM_REWARDS"
           ? "claim"
           : "action",
-      value: t(
-        `position_details.pending_action.${
-          pendingAction.pendingActionDto.type.toLowerCase() as Lowercase<
-            YieldPendingActionDto["type"]
-          >
-        }`
-      ),
+      value: formatPendingActionLabel(pendingAction.pendingActionDto.type, t),
     };
   }
 
@@ -634,6 +628,17 @@ const balanceTypePriority: YieldBalanceType[] = [
 
 const formatBalanceTypeLabel = (type: YieldBalanceType, t: TFunction) =>
   t(`position_details.balance_type.${type}`);
+
+// Pending action types come from the API and can outpace our translation map
+// (e.g. RWA-specific actions). Fall back to a humanized version of the type so
+// the card never renders a raw translation key.
+const formatPendingActionLabel = (
+  type: YieldPendingActionDto["type"],
+  t: TFunction
+) =>
+  t(`position_details.pending_action.${type.toLowerCase()}`, {
+    defaultValue: formatEnumValue(type),
+  });
 
 const formatUsdSubValue = (
   value: string | number | BigNumber | null | undefined

--- a/packages/widget/src/pages/position-details/components/static-action-block.tsx
+++ b/packages/widget/src/pages/position-details/components/static-action-block.tsx
@@ -10,6 +10,7 @@ import type {
 import type { YieldBalanceDto } from "../../../domain/types/positions";
 import { isEthenaUsdeStaking, type Yield } from "../../../domain/types/yields";
 import { defaultFormattedNumber } from "../../../utils";
+import { humanizePendingActionType } from "../../../utils/formatters";
 import type { usePositionDetails } from "../hooks/use-position-details";
 
 type StaticActionBlockProps = {
@@ -60,6 +61,9 @@ export const StaticActionBlock = ({
                   context: isEthenaUsdeStaking(yieldId)
                     ? "ethena_usde"
                     : undefined,
+                  defaultValue: humanizePendingActionType(
+                    pendingActionDto.type
+                  ),
                 }
               ),
             }}
@@ -93,7 +97,10 @@ export const StaticActionBlock = ({
             {t(
               `position_details.pending_action_button.${
                 pendingActionDto.type.toLowerCase() as Lowercase<YieldPendingActionType>
-              }`
+              }`,
+              {
+                defaultValue: humanizePendingActionType(pendingActionDto.type),
+              }
             )}
           </Text>
         </Button>

--- a/packages/widget/src/utils/formatters.ts
+++ b/packages/widget/src/utils/formatters.ts
@@ -136,6 +136,16 @@ export const formatCompactUsd = (value: string | number | null | undefined) => {
   return `$${compactUsdFormatter.format(amount.toNumber())}`;
 };
 
+// Pending action types come straight from the API and can outpace our
+// translation maps (e.g. RWA-specific actions like WITHDRAWAL_REQUEST). Use this
+// as the i18n `defaultValue`/`defaults` so we never render a raw translation key.
+export const humanizePendingActionType = (type: string): string =>
+  type
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+
 export const capitalizeFirstLetters = (text: string): string =>
   Maybe.fromNullable(text)
     .map((t) =>

--- a/packages/widget/src/utils/index.ts
+++ b/packages/widget/src/utils/index.ts
@@ -43,13 +43,13 @@ export const defaultFormattedNumber = (number: string | BigNumber | number) =>
 export const APToPercentage = (ap: number) =>
   formatNumber((ap * 100).toFixed(2));
 
-const colorsTuple = ["#6B69D6", "#F1C40F", "#1ABC9C", "#E74C3C"];
+// const colorsTuple = ["#6B69D6", "#F1C40F", "#1ABC9C", "#E74C3C"];
 
-export const getBackgroundColor = (stringInput: string) => {
-  const char = stringInput.charCodeAt(0);
+// export const getBackgroundColor = (stringInput: string) => {
+//   const char = stringInput.charCodeAt(0);
 
-  return colorsTuple[char % colorsTuple.length] ?? colorsTuple[0];
-};
+//   return colorsTuple[char % colorsTuple.length] ?? colorsTuple[0];
+// };
 
 export const isIframe = () =>
   MaybeWindow.map((w) => w.parent !== w).orDefault(false);


### PR DESCRIPTION
BEFORE: 
<img width="2406" height="568" alt="image" src="https://github.com/user-attachments/assets/e7bd5310-4e98-4744-826b-ce27e0bbe2f6" />

AFTER:
<img width="1690" height="1076" alt="image" src="https://github.com/user-attachments/assets/e6e4355c-6c7a-4176-9d3b-982196b8c2aa" />



- Render a grey circle with the chain initial when a network logo is missing or fails to load, on a white badge so dark chain logos (e.g. Ethereum) stay visible.
- Use a white background with black text for the token icon monogram fallback.
- Humanize unmapped pending action types (e.g. RWA actions) so the position details "Action required" card, action button, and review heading never render raw translation keys.

## Added

_Description of new functionality, feature, or content that has been added in this pull request._

## Changed

_Description of the modifications made to existing functionality, feature, or content in this pull request. This could include changes to code, CI, documentation, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved pending-action labels across the UI with humanized fallbacks when translations are missing.
  * Network logo component now receives the network name to improve fallback initials when logos fail.

* **Style**
  * Network icon container restyled with white background, reduced padding and a subtle ring shadow.
  * Monogram image background changed to a white circle with a light gray stroke for consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->