### PR TITLE
feat(widget): show error screen when no yields enabled for api key

### DIFF
--- a/packages/widget/src/App.tsx
+++ b/packages/widget/src/App.tsx
@@ -9,6 +9,8 @@ import { createMemoryRouter, RouterProvider } from "react-router";
 import { preloadImages } from "./assets/images";
 import { Box } from "./components/atoms/box";
 import { Dashboard } from "./Dashboard";
+import { useNoEnabledYields } from "./hooks/use-no-enabled-yields";
+import NoEnabledYields from "./pages/components/no-enabled-yields";
 import { Providers } from "./providers";
 import { SettingsContextProvider, useSettings } from "./providers/settings";
 import type { SettingsProps, VariantProps } from "./providers/settings/types";
@@ -22,6 +24,10 @@ const App = () => {
   useLoadErrorTranslations();
 
   const { dashboardVariant } = useSettings();
+
+  const noEnabledYields = useNoEnabledYields();
+
+  if (noEnabledYields) return <NoEnabledYields />;
 
   return dashboardVariant ? <Dashboard /> : <Widget />;
 };

--- a/packages/widget/src/common/get-enabled-networks.ts
+++ b/packages/widget/src/common/get-enabled-networks.ts
@@ -4,6 +4,19 @@ import { config } from "../config";
 import type { Networks } from "../domain/types/chains/networks";
 import type { ApiClient } from "../providers/api/api-client";
 
+export const enabledNetworksQueryKey = [config.appPrefix, "enabled-networks"];
+
+export const getEnabledNetworksQueryFn = async ({
+  apiClient,
+}: {
+  apiClient: ApiClient;
+}) =>
+  new Set(
+    (await apiClient.legacy.YieldControllerGetMyNetworks(undefined)).map(
+      (network) => network as Networks
+    )
+  );
+
 export const getEnabledNetworks = ({
   apiClient,
   queryClient,
@@ -14,12 +27,7 @@ export const getEnabledNetworks = ({
   EitherAsync(() =>
     queryClient.fetchQuery({
       staleTime: Number.POSITIVE_INFINITY,
-      queryKey: [config.appPrefix, "enabled-networks"],
-      queryFn: async () =>
-        new Set(
-          (await apiClient.legacy.YieldControllerGetMyNetworks(undefined)).map(
-            (network) => network as Networks
-          )
-        ),
+      queryKey: enabledNetworksQueryKey,
+      queryFn: () => getEnabledNetworksQueryFn({ apiClient }),
     })
   ).mapLeft(() => new Error("Could not get enabled networks"));

--- a/packages/widget/src/hooks/use-no-enabled-yields.ts
+++ b/packages/widget/src/hooks/use-no-enabled-yields.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  enabledNetworksQueryKey,
+  getEnabledNetworksQueryFn,
+} from "../common/get-enabled-networks";
+import { useApiClient } from "../providers/api/api-client-provider";
+
+export const useNoEnabledYields = () => {
+  const apiClient = useApiClient();
+
+  const { data, isSuccess } = useQuery({
+    staleTime: Number.POSITIVE_INFINITY,
+    queryKey: enabledNetworksQueryKey,
+    queryFn: () => getEnabledNetworksQueryFn({ apiClient }),
+  });
+
+  return isSuccess && data.size === 0;
+};

--- a/packages/widget/src/pages-dashboard/common/components/styles.css.ts
+++ b/packages/widget/src/pages-dashboard/common/components/styles.css.ts
@@ -12,7 +12,6 @@ export const wrapper = recipe({
       borderStyle: "solid",
       boxShadow: "0px 15px 40px 0px #0000000D",
       width: "1000px",
-      borderRadius: "14px",
     },
   ],
   variants: {

--- a/packages/widget/src/pages-dashboard/common/components/styles.css.ts
+++ b/packages/widget/src/pages-dashboard/common/components/styles.css.ts
@@ -12,6 +12,7 @@ export const wrapper = recipe({
       borderStyle: "solid",
       boxShadow: "0px 15px 40px 0px #0000000D",
       width: "1000px",
+      borderRadius: "14px",
     },
   ],
   variants: {

--- a/packages/widget/src/pages/components/no-enabled-yields/index.tsx
+++ b/packages/widget/src/pages/components/no-enabled-yields/index.tsx
@@ -14,6 +14,7 @@ const NoEnabledYields = () => {
 
   return (
     <Box
+      style={{ borderRadius: "14px" }}
       className={
         dashboardVariant
           ? [
@@ -38,7 +39,7 @@ const NoEnabledYields = () => {
             textAlign="center"
             variant={{ level: "h4" }}
           >
-            {t("no_enabled_yields.title")}
+            {t("help_modals.no_enabled_yields.title")}
           </Heading>
 
           <Text
@@ -46,7 +47,7 @@ const NoEnabledYields = () => {
             textAlign="center"
             marginBottom="4"
           >
-            {t("no_enabled_yields.description")}
+            {t("help_modals.no_enabled_yields.description")}
           </Text>
         </Box>
       </Box>

--- a/packages/widget/src/pages/components/no-enabled-yields/index.tsx
+++ b/packages/widget/src/pages/components/no-enabled-yields/index.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from "react-i18next";
+import { Box } from "../../../components/atoms/box";
+import { Heading } from "../../../components/atoms/typography/heading";
+import { Text } from "../../../components/atoms/typography/text";
+import { wrapper } from "../../../pages-dashboard/common/components/styles.css";
+import { useSettings } from "../../../providers/settings";
+import { combineRecipeWithVariant } from "../../../utils/styles";
+import { PoweredBy } from "../powered-by";
+import { background, container, dashboardBackground } from "./style.css";
+
+const NoEnabledYields = () => {
+  const { t } = useTranslation();
+  const { dashboardVariant, variant } = useSettings();
+
+  return (
+    <Box
+      className={
+        dashboardVariant
+          ? [
+              combineRecipeWithVariant({ rec: wrapper, variant }),
+              dashboardBackground,
+            ]
+          : background
+      }
+    >
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        paddingBottom={{ mobile: "8" }}
+        className={container}
+        data-testid="no-enabled-yields"
+      >
+        <Box>
+          <Heading
+            marginBottom="4"
+            textAlign="center"
+            variant={{ level: "h4" }}
+          >
+            {t("no_enabled_yields.title")}
+          </Heading>
+
+          <Text
+            variant={{ type: "muted", weight: "normal" }}
+            textAlign="center"
+            marginBottom="4"
+          >
+            {t("no_enabled_yields.description")}
+          </Text>
+        </Box>
+      </Box>
+      <PoweredBy opacity={1} />
+    </Box>
+  );
+};
+
+export default NoEnabledYields;

--- a/packages/widget/src/pages/components/no-enabled-yields/style.css.ts
+++ b/packages/widget/src/pages/components/no-enabled-yields/style.css.ts
@@ -1,0 +1,17 @@
+import { style } from "@vanilla-extract/css";
+import { animationContainer } from "../../../style.css";
+
+export const background = style([animationContainer, { minHeight: "560px" }]);
+
+export const dashboardBackground = style({
+  display: "flex",
+  flexDirection: "column",
+  overflow: "hidden",
+  minHeight: "600px",
+});
+
+export const container = style({
+  flexGrow: 1,
+  paddingLeft: "25px",
+  paddingRight: "25px",
+});

--- a/packages/widget/src/translation/English/translations.json
+++ b/packages/widget/src/translation/English/translations.json
@@ -553,11 +553,11 @@
       "title": "Under Maintenance",
       "description": "Yield.xyz is currently undergoing routine maintenance. Our service is expected to be back up and running in approximately 5-10 minutes.",
       "description2": "We appreciate your patience and encourage you to check back shortly!"
+    },
+    "no_enabled_yields": {
+      "title": "No yields enabled",
+      "description": "There are no yields enabled for this API key. Enable at least one yield to start earning."
     }
-  },
-  "no_enabled_yields": {
-    "title": "No yields enabled",
-    "description": "There are no yields enabled for this API key. Enable at least one yield to start earning."
   },
   "positions": {
     "title": "My Positions",

--- a/packages/widget/src/translation/English/translations.json
+++ b/packages/widget/src/translation/English/translations.json
@@ -555,6 +555,10 @@
       "description2": "We appreciate your patience and encourage you to check back shortly!"
     }
   },
+  "no_enabled_yields": {
+    "title": "No yields enabled",
+    "description": "There are no yields enabled for this API key. Enable at least one yield to start earning."
+  },
   "positions": {
     "title": "My Positions",
     "via_one": "via {{providerName}}",

--- a/packages/widget/src/translation/French/translations.json
+++ b/packages/widget/src/translation/French/translations.json
@@ -428,6 +428,10 @@
       "description2": "Nous apprécions votre patience et vous encourageons à revenir bientôt !"
     }
   },
+  "no_enabled_yields": {
+    "title": "Aucun rendement activé",
+    "description": "Aucun rendement n'est activé pour cette clé API. Activez au moins un rendement pour commencer à générer des intérêts."
+  },
   "positions": {
     "title": "Mes Positions",
     "via_one": "via {{providerName}}",

--- a/packages/widget/src/translation/French/translations.json
+++ b/packages/widget/src/translation/French/translations.json
@@ -426,11 +426,11 @@
       "title": "En maintenance",
       "description": "Yield.xyz est actuellement en maintenance de routine. Notre service devrait être de retour en ligne dans environ 5 à 10 minutes.",
       "description2": "Nous apprécions votre patience et vous encourageons à revenir bientôt !"
+    },
+    "no_enabled_yields": {
+      "title": "Aucun rendement activé",
+      "description": "Aucun rendement n'est activé pour cette clé API. Activez au moins un rendement pour commencer à générer des intérêts."
     }
-  },
-  "no_enabled_yields": {
-    "title": "Aucun rendement activé",
-    "description": "Aucun rendement n'est activé pour cette clé API. Activez au moins un rendement pour commencer à générer des intérêts."
   },
   "positions": {
     "title": "Mes Positions",


### PR DESCRIPTION
Empty screen added if api has no yields enabled

<img width="1162" height="778" alt="image" src="https://github.com/user-attachments/assets/20f24d8d-1efb-47e4-bea8-69a19d98cf9b" />

<img width="1152" height="843" alt="image" src="https://github.com/user-attachments/assets/5ad9a1e5-18a4-47e9-a74a-4ded2f4174e4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “No yields enabled” screen that appears when no yield options are active.
  * Included localized messaging in English and French to guide users to enable a yield before earning.

* **Bug Fixes**
  * Improved app behavior to show the appropriate fallback page instead of the standard dashboard flow when no enabled yields are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->