### PR TITLE
fix(widget): inherit token icon wrapper dimensions

### DIFF
--- a/packages/widget/src/components/atoms/token-icon/token-icon-image/index.tsx
+++ b/packages/widget/src/components/atoms/token-icon/token-icon-image/index.tsx
@@ -17,7 +17,7 @@ export const TokenIconImage = ({
   <Image
     data-rk="token-logo"
     wrapperProps={{ hw: tokenLogoHw, "data-rk": "token-logo" }}
-    imgProps={{ hw: tokenLogoHw }}
+    imgProps={{ hw: "full" }}
     src={mainUrl ?? fallbackUrl}
     fallbackName={name}
   />

--- a/packages/widget/tests/components/atoms/token-icon-image.test.tsx
+++ b/packages/widget/tests/components/atoms/token-icon-image.test.tsx
@@ -25,6 +25,30 @@ describe("TokenIconImage", () => {
     expect(image?.getAttribute("src")).toBe(validSrc);
   });
 
+  it("sizes the image from a host-overridden wrapper", async () => {
+    const app = await render(
+      <div data-test-host>
+        <style>{`
+          [data-test-host] [data-rk="token-logo"] {
+            width: 24px;
+            height: 24px;
+          }
+        `}</style>
+        <TokenIconImage mainUrl={validSrc} name="Atom" tokenLogoHw="9" />
+      </div>
+    );
+
+    const wrapper = app.container.querySelector<HTMLElement>(
+      '[data-rk="token-logo"]'
+    );
+    const image = wrapper?.querySelector<HTMLImageElement>("img");
+
+    expect(wrapper?.getBoundingClientRect().width).toBe(24);
+    expect(wrapper?.getBoundingClientRect().height).toBe(24);
+    expect(image?.getBoundingClientRect().width).toBe(24);
+    expect(image?.getBoundingClientRect().height).toBe(24);
+  });
+
   it("falls through to the generated monogram after mainUrl fails", async () => {
     const app = await render(
       <TokenIconImage


### PR DESCRIPTION
Keep token images sized relative to their wrapper so host overrides preserve square assets.

Add regression coverage for a 24px host-provided token logo size.

## Added

_Description of new functionality, feature, or content that has been added in this pull request._

## Changed

_Description of the modifications made to existing functionality, feature, or content in this pull request. This could include changes to code, CI, documentation, etc._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized widget UI sizing change with unit test coverage; no auth, data, or API impact.
> 
> **Overview**
> **Token logos now fill their wrapper** instead of duplicating the `tokenLogoHw` size on the inner `img`, so host CSS that resizes `[data-rk="token-logo"]` keeps square icons.
> 
> `TokenIconImage` still applies `tokenLogoHw` on the wrapper; `imgProps` now use `hw: "full"`. A regression test asserts a 24px host override sizes both wrapper and image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d467df72f3a8e1a240cfd6e3d699a46d9edbd7b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->